### PR TITLE
Updates to remediate 403 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,13 @@ Tip: run the exact command once in PowerShell first to confirm it works before s
 
 ### How it works (high level)
 - Logs into your servicer portal (typically `https://{provider}.studentaid.gov`) with Playwright
+- Browser sessions use **stealth defaults** (automation flags disabled, realistic viewport/locale/user-agent, randomized interaction delays) to reduce anti-automation detection
 - When the portal prompts for MFA, selects **Email**, then polls Gmail IMAP for the code
 - Scrapes per-loan balances + payment allocation details
+  - **Non-posted payments** (pending, scheduled, processing, cancelled) are automatically detected and skipped — only fully posted payments are synced
 - Pushes updates into Monarch via the unofficial Monarch API client
 - Stores a small SQLite state DB so runs are **idempotent** (no duplicate payment transactions)
-- Includes an extra **duplicate guard** against Monarch itself: **date + amount + merchant** (so even if you reset SQLite, we won't spam duplicates).
+- Includes an extra **duplicate guard** against Monarch itself: **date + amount + merchant** (so even if you reset SQLite, we won’t spam duplicates).
   - Optional: you can enable a more specific duplicate check that also uses the portal’s **payment confirmation/reference** as a search term (see [Config notes (Monarch payments)](#config-notes-monarch-payments)).
 
 <a id="gmail-imap-setup"></a>
@@ -301,6 +303,8 @@ If a `sync` run fails, the CLI will automatically create a zip under `data/` con
 - `data/debug/*` (screenshots/HTML/text snapshots)
 - your configured log file (default: `data/sync.log`)
 
+The log file now includes the **full exception traceback** for run failures, so you can see the exact line and error without needing to reproduce the issue interactively.
+
 You can attach that zip when asking for help.
 
 #### Parsing debug text snapshots (offline)
@@ -317,6 +321,8 @@ See **Quick start → Runtime A: Docker (recommended)** for the Unraid schedulin
 ### Notes / stability
 - StudentAid servicer portals are web portals; UI changes may break selectors. The code is structured so selectors live in one place, and failures should save screenshots/logs for debugging.
 - Email MFA automation is sensitive—use a dedicated mailbox if possible.
+- **Non-posted payment handling**: payments with status _pending_, _scheduled_, _processing_, or _cancelled_ are automatically skipped. Only fully posted (electronic/regular) payments produce Monarch transactions. If a single row fails to parse, it is skipped with a warning rather than aborting the whole run.
+- **Anti-automation / 403 detection**: if the portal returns an HTTP 403 Access Denied (common in headless runs on some servicers), the tool detects it immediately, saves a debug snapshot, and retries once with a fresh session. If it persists, see the [403 troubleshooting entry](#403-access-denied) below.
 - State self-heal:
   - `data/state.db` (SQLite idempotency DB) is backed up to `data/state.db.bak`. If `state.db` is corrupted/unreadable, the script will restore from the backup (or recreate it if no backup exists).
   - `data/servicer_storage_state_*.json` (Playwright cookies/localStorage) is backed up to `*.bak`. If it becomes invalid JSON, the script quarantines it and falls back to a fresh session.
@@ -330,6 +336,16 @@ See **Quick start → Runtime A: Docker (recommended)** for the Unraid schedulin
   - Confirm Gmail IMAP is enabled and `GMAIL_IMAP_FOLDER` matches the label name.
   - Set broad hints: `GMAIL_IMAP_SENDER_HINT=studentaid.gov` and `GMAIL_IMAP_SUBJECT_HINT=code`.
   - Make sure the filter applies the label and the email isn’t in Spam.
+
+<a id="403-access-denied"></a>
+- **HTTP 403 Access Denied / portal blocks the headless browser**
+  - Some servicers (notably Nelnet) occasionally return a bare `HTTP 403 Access Denied` page to headless browsers that look like automation. The tool detects this and retries once with a fresh session automatically.
+  - If it keeps failing, try the following in order:
+    1. Run `sync --headful --manual-mfa` once to establish a fresh, trusted browser session stored under `data/servicer_storage_state_*.json`. Subsequent headless runs reuse that session.
+    2. Add `--fresh-session` to force discarding any stale stored session before retrying.
+    3. If running in Docker on a cloud/datacenter host, try from a residential IP address — some portal WAFs block datacenter IP ranges.
+  - A `data/debug/access_denied_403_*.png` screenshot is saved automatically so you can confirm what the portal returned.
+  - See also [GitHub issue #9](https://github.com/mattebad/monarch-studentaid-sync/issues/9) for community discussion.
 
 ### Config notes (Monarch payments)
 - `monarch.payment_merchant_name`: merchant name to use when creating payment transactions, and the value used by the **duplicate guard**.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Tip: run the exact command once in PowerShell first to confirm it works before s
 
 ### How it works (high level)
 - Logs into your servicer portal (typically `https://{provider}.studentaid.gov`) with Playwright
-- Browser sessions use **stealth defaults** (automation flags disabled, realistic viewport/locale/user-agent, randomized interaction delays) to reduce anti-automation detection
+- Browser sessions use **browser-compatibility defaults** (automation flags disabled, realistic viewport/locale/user-agent, randomized interaction delays) to reduce anti-automation detection
 - When the portal prompts for MFA, selects **Email**, then polls Gmail IMAP for the code
 - Scrapes per-loan balances + payment allocation details
   - **Non-posted payments** (pending, scheduled, processing, cancelled) are automatically detected and skipped — only fully posted payments are synced

--- a/src/studentaid_monarch_sync/portal/client.py
+++ b/src/studentaid_monarch_sync/portal/client.py
@@ -182,14 +182,6 @@ class ServicerPortalClient:
                         continue
                 raise
 
-    # Used only when falling back to Playwright's bundled Chromium in headless mode.
-    # Keep the Chrome major version aligned with the Playwright dependency.
-    _BUNDLED_CHROMIUM_USER_AGENT = (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/131.0.0.0 Safari/537.36"
-    )
-
     def _create_browser_context(self, browser, *, storage_state: Optional[str] = None):
         """
         Create a browser context with realistic fingerprint settings.
@@ -198,13 +190,10 @@ class ServicerPortalClient:
             "color_scheme": "light",
             "viewport": {"width": 1920, "height": 1080},
             "locale": "en-US",
+            "extra_http_headers": {"Accept-Language": "en-US,en;q=0.9"},
         }
         if storage_state:
             ctx_kwargs["storage_state"] = storage_state
-
-        # Only override user-agent when using bundled Chromium (real Chrome already has a good UA).
-        if not self._using_real_chrome_channel:
-            ctx_kwargs["user_agent"] = self._BUNDLED_CHROMIUM_USER_AGENT
 
         return browser.new_context(**ctx_kwargs)
 
@@ -916,9 +905,19 @@ class ServicerPortalClient:
         try:
             # Catch mid-session 403s as well (not just on the initial goto).
             # Some servicer portals return a bare 403 page with minimal body content.
+            saw_403_document = {"value": False}
             def _on_response(resp) -> None:
                 try:
                     if resp.status == 403:
+                        # Only treat 403 as fatal when it is for the main document navigation.
+                        # Some portals may return 403 for subresources; failing fast on those
+                        # can create false positives.
+                        try:
+                            req = resp.request
+                            if req.resource_type == "document" and req.frame == page.main_frame:
+                                saw_403_document["value"] = True
+                        except Exception:
+                            pass
                         self._save_debug(page, debug_dir=debug_dir, name_prefix="access_denied_403_response")
                 except Exception:
                     pass
@@ -927,6 +926,10 @@ class ServicerPortalClient:
 
             page.goto(self.base_url, wait_until="domcontentloaded")
             self._wait_for_settle(page)
+            if saw_403_document["value"]:
+                # Prefer failing fast into the retry loop rather than continuing to parse a blocked session.
+                self._raise_if_access_denied(page, debug_dir=debug_dir)
+            self._raise_if_access_denied(page, debug_dir=debug_dir)
             self._step(page, debug_dir=debug_dir, name="after_goto")
             self._dismiss_cookie_banner(page)
             self._step(page, debug_dir=debug_dir, name="after_cookie_dismiss")

--- a/src/studentaid_monarch_sync/portal/client.py
+++ b/src/studentaid_monarch_sync/portal/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import json
+import random
 import re
 import shutil
 import time
@@ -26,6 +27,12 @@ logger = logging.getLogger(__name__)
 class LoginFormNotFoundError(RuntimeError):
     """
     Raised when we cannot locate the portal login form (username field) after trying common entry points.
+    """
+
+
+class PortalAccessDeniedError(RuntimeError):
+    """
+    Raised when the servicer portal returns HTTP 403 / Access Denied.
     """
 
 
@@ -84,9 +91,12 @@ class ServicerPortalClient:
         });
       } catch (_) {}
 
-      // Chrome runtime presence (headless Chrome lacks this)
+      // Chrome runtime presence (headless Chrome often lacks this)
       try {
-        if (!window.chrome) { window.chrome = { runtime: {} }; }
+        if (!window.chrome) { window.chrome = {}; }
+        if (!window.chrome.runtime) { window.chrome.runtime = {}; }
+        if (!window.chrome.app) { window.chrome.app = {}; }
+        if (!window.chrome.csi) { window.chrome.csi = () => ({ startE: Date.now() }); }
       } catch (_) {}
 
       // Permissions query normalization
@@ -97,6 +107,48 @@ class ServicerPortalClient:
             parameters.name === 'notifications'
               ? Promise.resolve({ state: Notification.permission })
               : originalQuery(parameters);
+        }
+      } catch (_) {}
+
+      // Headless Chrome often reports empty plugins/mimeTypes.
+      try {
+        if (!navigator.plugins || navigator.plugins.length === 0) {
+          const fake = [
+            { name: 'Chrome PDF Plugin' },
+            { name: 'Chrome PDF Viewer' },
+            { name: 'Native Client' },
+          ];
+          Object.defineProperty(navigator, 'plugins', {
+            get: () => fake,
+          });
+        }
+      } catch (_) {}
+
+      try {
+        if (!navigator.mimeTypes || navigator.mimeTypes.length === 0) {
+          const fake = [{ type: 'application/pdf' }, { type: 'text/pdf' }];
+          Object.defineProperty(navigator, 'mimeTypes', {
+            get: () => fake,
+          });
+        }
+      } catch (_) {}
+
+      // Avoid obvious SwiftShader renderer fingerprints in headless.
+      try {
+        const _getParameter = WebGLRenderingContext.prototype.getParameter;
+        WebGLRenderingContext.prototype.getParameter = function (parameter) {
+          if (parameter === 37445) return 'Google Inc. (Intel)';
+          if (parameter === 37446) return 'ANGLE (Intel, Intel(R) UHD Graphics, OpenGL 4.1)';
+          return _getParameter.apply(this, [parameter]);
+        };
+      } catch (_) {}
+
+      // Best-effort cleanup of commonly checked CDP leak globals.
+      try {
+        for (const k of Object.keys(window)) {
+          if (k.startsWith('cdc_')) {
+            try { delete window[k]; } catch (_) {}
+          }
         }
       } catch (_) {}
     })();
@@ -141,20 +193,24 @@ class ServicerPortalClient:
 
     def _launch_browser(self, p, *, headless: bool, slow_mo: int):
         """
-        Launch a Chromium-based browser with browser compatibility hardening.
+        Launch Chromium with anti-detection defaults.
 
-        Prefers a real Chrome channel (less fingerprintable) over bundled Chromium in headless mode.
-        Falls back through Chrome -> Edge -> bundled Chromium.
+        For headless runs, prefer Chromium's newer headless mode by passing
+        `--headless=new` and using `headless=False` at Playwright level.
         """
         args = list(self._BROWSER_COMPAT_LAUNCH_ARGS)
-        launch_kwargs = dict(headless=headless, slow_mo=slow_mo, args=args)
+        launch_headless = bool(headless)
+        if headless:
+            args.append("--headless=new")
+            launch_headless = False
+
+        launch_kwargs = dict(headless=launch_headless, slow_mo=slow_mo, args=args)
 
         if headless:
-            # Prefer real Chrome first (better fingerprint), fall back to bundled Chromium.
             for channel in ("chrome", "msedge", None):
                 try:
                     kw = {**launch_kwargs}
-                    if channel:
+                    if channel is not None:
                         kw["channel"] = channel
                     browser = p.chromium.launch(**kw)
                     self._using_real_chrome_channel = channel is not None
@@ -162,31 +218,35 @@ class ServicerPortalClient:
                 except Exception:
                     continue
             raise RuntimeError("Could not launch any Chromium-based browser (tried chrome, msedge, bundled).")
-        else:
-            # Headful: try bundled Chromium first (allows devtools), fall back to installed channels.
-            try:
-                browser = p.chromium.launch(**launch_kwargs)
-                self._using_real_chrome_channel = False
-                return browser
-            except Exception as e:
-                msg = str(e)
-                if "Executable doesn't exist" not in msg:
-                    raise
-                logger.warning("Playwright Chromium executable missing; falling back to system browser channel. (%s)", msg)
-                for channel in ("chrome", "msedge"):
-                    try:
-                        browser = p.chromium.launch(**{**launch_kwargs, "channel": channel})
-                        self._using_real_chrome_channel = True
-                        return browser
-                    except Exception:
-                        continue
+
+        try:
+            browser = p.chromium.launch(**launch_kwargs)
+            self._using_real_chrome_channel = False
+            return browser
+        except Exception as e:
+            msg = str(e)
+            if "Executable doesn't exist" not in msg and "Executable doesn't exist at" not in msg:
                 raise
+            logger.warning("Playwright Chromium executable missing; falling back to system browser channel. (%s)", msg)
+            for channel in ("chrome", "msedge"):
+                try:
+                    browser = p.chromium.launch(**{**launch_kwargs, "channel": channel})
+                    self._using_real_chrome_channel = True
+                    return browser
+                except Exception:
+                    continue
+            raise
 
     def _create_browser_context(self, browser, *, storage_state: Optional[str] = None):
         """
         Create a browser context with realistic fingerprint settings.
         """
         ctx_kwargs: dict = {
+            "user_agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/131.0.0.0 Safari/537.36"
+            ),
             "color_scheme": "light",
             "viewport": {"width": 1920, "height": 1080},
             "locale": "en-US",
@@ -222,6 +282,7 @@ class ServicerPortalClient:
     def _human_delay(self, page: Page, min_ms: int = 80, max_ms: int = 250) -> None:
         """Inject a small randomized delay to mimic human interaction timing."""
         page.wait_for_timeout(random.randint(min_ms, max_ms))
+
     def extract(
         self,
         *,
@@ -252,90 +313,11 @@ class ServicerPortalClient:
         Path(debug_dir).mkdir(parents=True, exist_ok=True)
 
         def _install_context_hooks(ctx) -> None:
-            # Rewrite the occasionally-seen "dark" host back to the canonical host.
-            # We have observed headful sessions sometimes ending up on:
-            #   https://dark.<servicer>.studentaid.gov/...
-            # which frequently fails DNS resolution on some machines (NXDOMAIN).
-            try:
-                if not self._dark_host or not self._canonical_host:
-                    raise RuntimeError("canonical host missing")
-
-                def _rewrite(route, request) -> None:
-                    url = request.url
-                    fixed = url.replace(f"://{self._dark_host}", f"://{self._canonical_host}")
-                    route.continue_(url=fixed)
-
-                ctx.route(
-                    re.compile(rf".*://{re.escape(self._dark_host)}/.*", re.I),
-                    _rewrite,
-                )
-            except Exception:
-                logger.debug("Failed to install dark-host rewrite route.", exc_info=True)
-
-            # The portal uses a Transcend consent manager ("This site uses cookies") that can render
-            # inside a shadow root and intercept clicks (including the federal disclaimer).
-            # Install an init script so the consent UI is dismissed/hidden as soon as it mounts.
-            ctx.add_init_script(
-                """
-                (() => {
-                  const dismiss = () => {
-                    // If consent UI is in light DOM, try clicking "Accept all"
-                    try {
-                      const accept = Array.from(document.querySelectorAll('button'))
-                        .find(b => /accept\\s+all/i.test((b.textContent || '').trim()));
-                      if (accept && /this\\s+site\\s+uses\\s+cookies/i.test(document.body?.innerText || '')) {
-                        accept.click();
-                      }
-                    } catch (_) {}
-
-                    // If consent UI is in an OPEN shadow root, try clicking "Accept all"
-                    try {
-                      const host = document.getElementById('transcend-consent-manager');
-                      const root = host && host.shadowRoot;
-                      if (root) {
-                        const accept = Array.from(root.querySelectorAll('button'))
-                          .find(b => /accept\\s+all/i.test((b.textContent || '').trim()));
-                        if (accept) accept.click();
-                      }
-                    } catch (_) {}
-
-                    // Always hide the host so it cannot intercept clicks (works even if shadow root is CLOSED)
-                    try {
-                      const host = document.getElementById('transcend-consent-manager');
-                      if (host) {
-                        host.style.setProperty('display', 'none', 'important');
-                        host.style.setProperty('pointer-events', 'none', 'important');
-                      }
-                    } catch (_) {}
-                  };
-
-                  dismiss();
-                  new MutationObserver(() => dismiss()).observe(document.documentElement, { childList: true, subtree: true });
-                })();
-                """
-            )
+            # Keep local callsites unchanged while delegating to the shared implementation.
+            self._install_context_hooks(ctx)
 
         with sync_playwright() as p:
-            # Prefer Playwright's bundled Chromium, but fall back to a system-installed browser if the
-            # sandbox/cache doesn't have Playwright browsers available.
-            slow_mo = int(slow_mo_ms or 0)
-            try:
-                browser = p.chromium.launch(headless=headless, slow_mo=slow_mo)
-            except Exception as e:
-                msg = str(e)
-                if "Executable doesn't exist" not in msg and "Executable doesn't exist at" not in msg:
-                    raise
-
-                logger.warning(
-                    "Playwright Chromium executable missing; falling back to system browser channel. (%s)",
-                    msg,
-                )
-
-                # Try Chrome first, then Edge.
-                try:
-                    browser = p.chromium.launch(headless=headless, slow_mo=slow_mo, channel="chrome")
-                except Exception:
-                    browser = p.chromium.launch(headless=headless, slow_mo=slow_mo, channel="msedge")
+            browser = self._launch_browser(p, headless=headless, slow_mo=int(slow_mo_ms or 0))
             try:
                 # Attempt 1: reuse stored session (unless force_fresh_session).
                 # Attempt 2: fresh session (no stored cookies) — helpful when stored state causes
@@ -355,16 +337,11 @@ class ServicerPortalClient:
                     if use_storage and state_path is not None:
                         use_storage = self._validate_or_restore_storage_state(state_path)
 
-                    ctx_kwargs: dict = {}
-                    if use_storage:
-                        ctx_kwargs["storage_state"] = str(state_path)
-
-                    # Force light color scheme.
-                    ctx_kwargs["color_scheme"] = "light"
+                    storage = str(state_path) if use_storage else None
 
                     ctx = None
                     try:
-                        ctx = browser.new_context(**ctx_kwargs)
+                        ctx = self._create_browser_context(browser, storage_state=storage)
                     except Exception as e:
                         # If storage_state is invalid/corrupt, Playwright can fail before we ever get a Page.
                         if use_storage and state_path is not None:
@@ -373,9 +350,8 @@ class ServicerPortalClient:
                                 e,
                             )
                             self._quarantine_file(state_path, prefix="storage_state")
-                            ctx_kwargs.pop("storage_state", None)
                             use_storage = False
-                            ctx = browser.new_context(**ctx_kwargs)
+                            ctx = self._create_browser_context(browser, storage_state=None)
                         else:
                             raise
 
@@ -430,7 +406,8 @@ class ServicerPortalClient:
                                 and isinstance(e, LoginFormNotFoundError)
                                 and not self._looks_logged_in(page)
                             )
-                            if retry_for_browser_error or retry_for_login_form:
+                            retry_for_access_denied = isinstance(e, PortalAccessDeniedError)
+                            if retry_for_browser_error or retry_for_login_form or retry_for_access_denied:
                                 logger.warning(
                                     "Portal navigation/login failed%s; retrying once with a fresh session (no stored cookies).",
                                     " (stored session)" if use_storage else "",
@@ -473,65 +450,10 @@ class ServicerPortalClient:
         Path(debug_dir).mkdir(parents=True, exist_ok=True)
 
         def _install_context_hooks(ctx) -> None:
-            # Keep behavior consistent with `extract()`.
-            try:
-                if not self._dark_host or not self._canonical_host:
-                    raise RuntimeError("canonical host missing")
-
-                def _rewrite(route, request) -> None:
-                    url = request.url
-                    fixed = url.replace(f"://{self._dark_host}", f"://{self._canonical_host}")
-                    route.continue_(url=fixed)
-
-                ctx.route(
-                    re.compile(rf".*://{re.escape(self._dark_host)}/.*", re.I),
-                    _rewrite,
-                )
-            except Exception:
-                logger.debug("Failed to install dark-host rewrite route.", exc_info=True)
-
-            ctx.add_init_script(
-                """
-                (() => {
-                  const dismiss = () => {
-                    try {
-                      const accept = Array.from(document.querySelectorAll('button'))
-                        .find(b => /accept\\s+all/i.test((b.textContent || '').trim()));
-                      if (accept && /this\\s+site\\s+uses\\s+cookies/i.test(document.body?.innerText || '')) {
-                        accept.click();
-                      }
-                    } catch (_) {}
-
-                    try {
-                      const host = document.getElementById('transcend-consent-manager');
-                      const root = host && host.shadowRoot;
-                      if (root) {
-                        const accept = Array.from(root.querySelectorAll('button'))
-                          .find(b => /accept\\s+all/i.test((b.textContent || '').trim()));
-                        if (accept) accept.click();
-                      }
-                    } catch (_) {}
-
-                    try {
-                      const host = document.getElementById('transcend-consent-manager');
-                      if (host) {
-                        host.style.setProperty('display', 'none', 'important');
-                        host.style.setProperty('pointer-events', 'none', 'important');
-                      }
-                    } catch (_) {}
-                  };
-
-                  try {
-                    const observer = new MutationObserver(() => dismiss());
-                    observer.observe(document.documentElement, { childList: true, subtree: true });
-                    dismiss();
-                  } catch (_) {}
-                })();
-                """
-            )
+            self._install_context_hooks(ctx)
 
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=headless, slow_mo=slow_mo_ms)
+            browser = self._launch_browser(p, headless=headless, slow_mo=int(slow_mo_ms or 0))
             try:
                 for attempt_idx in range(2):
                     use_storage = (
@@ -540,14 +462,11 @@ class ServicerPortalClient:
                     if use_storage and state_path is not None:
                         use_storage = self._validate_or_restore_storage_state(state_path)
 
-                    ctx_kwargs: dict = {}
-                    if use_storage:
-                        ctx_kwargs["storage_state"] = str(state_path)
-                    ctx_kwargs["color_scheme"] = "light"
+                    storage = str(state_path) if use_storage else None
 
                     ctx = None
                     try:
-                        ctx = browser.new_context(**ctx_kwargs)
+                        ctx = self._create_browser_context(browser, storage_state=storage)
                     except Exception as e:
                         if use_storage and state_path is not None:
                             logger.warning(
@@ -555,9 +474,8 @@ class ServicerPortalClient:
                                 e,
                             )
                             self._quarantine_file(state_path, prefix="storage_state")
-                            ctx_kwargs.pop("storage_state", None)
                             use_storage = False
-                            ctx = browser.new_context(**ctx_kwargs)
+                            ctx = self._create_browser_context(browser, storage_state=None)
                         else:
                             raise
 
@@ -617,7 +535,8 @@ class ServicerPortalClient:
                             retry_for_login_form = (
                                 use_storage and isinstance(e, LoginFormNotFoundError) and not self._looks_logged_in(page)
                             )
-                            if retry_for_browser_error or retry_for_login_form:
+                            retry_for_access_denied = isinstance(e, PortalAccessDeniedError)
+                            if retry_for_browser_error or retry_for_login_form or retry_for_access_denied:
                                 logger.warning(
                                     "Portal navigation/login failed%s; retrying once with a fresh session (no stored cookies).",
                                     " (stored session)" if use_storage else "",
@@ -696,58 +615,20 @@ class ServicerPortalClient:
                 pass
 
         def _install_context_hooks(ctx) -> None:
-            # Same stability hooks as extract()/discover.
-            try:
-                if self._dark_host and self._canonical_host:
-                    def _rewrite(route, request) -> None:
-                        url = request.url
-                        fixed = url.replace(f"://{self._dark_host}", f"://{self._canonical_host}")
-                        route.continue_(url=fixed)
-
-                    ctx.route(re.compile(rf".*://{re.escape(self._dark_host)}/.*", re.I), _rewrite)
-            except Exception:
-                logger.debug("Failed to install dark-host rewrite route.", exc_info=True)
-
-            ctx.add_init_script(
-                """
-                (() => {
-                  const dismiss = () => {
-                    try {
-                      const accept = Array.from(document.querySelectorAll('button'))
-                        .find(b => /accept\\s+all/i.test((b.textContent || '').trim()));
-                      if (accept && /this\\s+site\\s+uses\\s+cookies/i.test(document.body?.innerText || '')) {
-                        accept.click();
-                      }
-                    } catch (_) {}
-                    try {
-                      const host = document.getElementById('transcend-consent-manager');
-                      if (host) {
-                        host.style.setProperty('display', 'none', 'important');
-                        host.style.setProperty('pointer-events', 'none', 'important');
-                      }
-                    } catch (_) {}
-                  };
-                  try {
-                    const observer = new MutationObserver(() => dismiss());
-                    observer.observe(document.documentElement, { childList: true, subtree: true });
-                    dismiss();
-                  } catch (_) {}
-                })();
-                """
-            )
+            self._install_context_hooks(ctx)
 
         bundle_path: Optional[Path] = None
         err: Optional[BaseException] = None
         try:
             with sync_playwright() as p:
-                browser = p.chromium.launch(headless=headless, slow_mo=int(slow_mo_ms or 0))
+                browser = self._launch_browser(p, headless=headless, slow_mo=int(slow_mo_ms or 0))
                 try:
-                    ctx_kwargs: dict = {"color_scheme": "light"}
+                    storage = None
                     if state_path and state_path.exists() and not force_fresh_session:
                         if self._validate_or_restore_storage_state(state_path):
-                            ctx_kwargs["storage_state"] = str(state_path)
+                            storage = str(state_path)
 
-                    ctx = browser.new_context(**ctx_kwargs)
+                    ctx = self._create_browser_context(browser, storage_state=storage)
                     try:
                         _install_context_hooks(ctx)
 
@@ -1709,6 +1590,7 @@ class ServicerPortalClient:
                 "  3. Ensure you are not running from a datacenter IP with poor reputation.\n"
                 "See https://github.com/mattebad/monarch-studentaid-sync/issues/9 for discussion."
             )
+
     def _extract_loans(
         self,
         page: Page,

--- a/src/studentaid_monarch_sync/portal/client.py
+++ b/src/studentaid_monarch_sync/portal/client.py
@@ -61,6 +61,178 @@ class ServicerPortalClient:
         self._step_counter: int = 0
         self._step_delay_ms: int = 0
 
+        # Tracks whether _launch_browser used a real Chrome channel (affects UA override logic).
+        self._using_real_chrome_channel: bool = False
+
+    # ------------------------------------------------------------------
+    # Shared browser bootstrap helpers (browser-compatibility hardened)
+    # ------------------------------------------------------------------
+
+    _BROWSER_COMPAT_LAUNCH_ARGS = [
+        "--disable-blink-features=AutomationControlled",
+    ]
+
+    _BROWSER_COMPAT_INIT_SCRIPT = r"""
+    (() => {
+      // Mask navigator.webdriver
+      try { Object.defineProperty(navigator, 'webdriver', { get: () => undefined }); } catch (_) {}
+
+      // Realistic languages
+      try {
+        Object.defineProperty(navigator, 'languages', {
+          get: () => ['en-US', 'en'],
+        });
+      } catch (_) {}
+
+      // Chrome runtime presence (headless Chrome lacks this)
+      try {
+        if (!window.chrome) { window.chrome = { runtime: {} }; }
+      } catch (_) {}
+
+      // Permissions query normalization
+      try {
+        const originalQuery = window.navigator.permissions?.query;
+        if (originalQuery) {
+          window.navigator.permissions.query = (parameters) =>
+            parameters.name === 'notifications'
+              ? Promise.resolve({ state: Notification.permission })
+              : originalQuery(parameters);
+        }
+      } catch (_) {}
+    })();
+    """
+
+    _CONSENT_DISMISS_SCRIPT = """
+    (() => {
+      const dismiss = () => {
+        try {
+          const accept = Array.from(document.querySelectorAll('button'))
+            .find(b => /accept\\s+all/i.test((b.textContent || '').trim()));
+          if (accept && /this\\s+site\\s+uses\\s+cookies/i.test(document.body?.innerText || '')) {
+            accept.click();
+          }
+        } catch (_) {}
+
+        try {
+          const host = document.getElementById('transcend-consent-manager');
+          const root = host && host.shadowRoot;
+          if (root) {
+            const accept = Array.from(root.querySelectorAll('button'))
+              .find(b => /accept\\s+all/i.test((b.textContent || '').trim()));
+            if (accept) accept.click();
+          }
+        } catch (_) {}
+
+        try {
+          const host = document.getElementById('transcend-consent-manager');
+          if (host) {
+            host.style.setProperty('display', 'none', 'important');
+            host.style.setProperty('pointer-events', 'none', 'important');
+          }
+        } catch (_) {}
+      };
+
+      try {
+        dismiss();
+        new MutationObserver(() => dismiss()).observe(document.documentElement, { childList: true, subtree: true });
+      } catch (_) {}
+    })();
+    """
+
+    def _launch_browser(self, p, *, headless: bool, slow_mo: int):
+        """
+        Launch a Chromium-based browser with browser compatibility hardening.
+
+        Prefers a real Chrome channel (less fingerprintable) over bundled Chromium in headless mode.
+        Falls back through Chrome -> Edge -> bundled Chromium.
+        """
+        args = list(self._BROWSER_COMPAT_LAUNCH_ARGS)
+        launch_kwargs = dict(headless=headless, slow_mo=slow_mo, args=args)
+
+        if headless:
+            # Prefer real Chrome first (better fingerprint), fall back to bundled Chromium.
+            for channel in ("chrome", "msedge", None):
+                try:
+                    kw = {**launch_kwargs}
+                    if channel:
+                        kw["channel"] = channel
+                    browser = p.chromium.launch(**kw)
+                    self._using_real_chrome_channel = channel is not None
+                    return browser
+                except Exception:
+                    continue
+            raise RuntimeError("Could not launch any Chromium-based browser (tried chrome, msedge, bundled).")
+        else:
+            # Headful: try bundled Chromium first (allows devtools), fall back to installed channels.
+            try:
+                browser = p.chromium.launch(**launch_kwargs)
+                self._using_real_chrome_channel = False
+                return browser
+            except Exception as e:
+                msg = str(e)
+                if "Executable doesn't exist" not in msg:
+                    raise
+                logger.warning("Playwright Chromium executable missing; falling back to system browser channel. (%s)", msg)
+                for channel in ("chrome", "msedge"):
+                    try:
+                        browser = p.chromium.launch(**{**launch_kwargs, "channel": channel})
+                        self._using_real_chrome_channel = True
+                        return browser
+                    except Exception:
+                        continue
+                raise
+
+    # Used only when falling back to Playwright's bundled Chromium in headless mode.
+    # Keep the Chrome major version aligned with the Playwright dependency.
+    _BUNDLED_CHROMIUM_USER_AGENT = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/131.0.0.0 Safari/537.36"
+    )
+
+    def _create_browser_context(self, browser, *, storage_state: Optional[str] = None):
+        """
+        Create a browser context with realistic fingerprint settings.
+        """
+        ctx_kwargs: dict = {
+            "color_scheme": "light",
+            "viewport": {"width": 1920, "height": 1080},
+            "locale": "en-US",
+        }
+        if storage_state:
+            ctx_kwargs["storage_state"] = storage_state
+
+        # Only override user-agent when using bundled Chromium (real Chrome already has a good UA).
+        if not self._using_real_chrome_channel:
+            ctx_kwargs["user_agent"] = self._BUNDLED_CHROMIUM_USER_AGENT
+
+        return browser.new_context(**ctx_kwargs)
+
+    def _install_context_hooks(self, ctx) -> None:
+        """
+        Install route rewrites, browser compatibility patches, and consent-manager dismissal on a browser context.
+        """
+        # Rewrite the occasionally-seen "dark" host back to the canonical host.
+        try:
+            if self._dark_host and self._canonical_host:
+                def _rewrite(route, request) -> None:
+                    url = request.url
+                    fixed = url.replace(f"://{self._dark_host}", f"://{self._canonical_host}")
+                    route.continue_(url=fixed)
+
+                ctx.route(
+                    re.compile(rf".*://{re.escape(self._dark_host)}/.*", re.I),
+                    _rewrite,
+                )
+        except Exception:
+            logger.debug("Failed to install dark-host rewrite route.", exc_info=True)
+
+        ctx.add_init_script(self._BROWSER_COMPAT_INIT_SCRIPT)
+        ctx.add_init_script(self._CONSENT_DISMISS_SCRIPT)
+
+    def _human_delay(self, page: Page, min_ms: int = 80, max_ms: int = 250) -> None:
+        """Inject a small randomized delay to mimic human interaction timing."""
+        page.wait_for_timeout(random.randint(min_ms, max_ms))
     def extract(
         self,
         *,
@@ -742,6 +914,17 @@ class ServicerPortalClient:
         manual_mfa: bool = False,
     ) -> None:
         try:
+            # Catch mid-session 403s as well (not just on the initial goto).
+            # Some servicer portals return a bare 403 page with minimal body content.
+            def _on_response(resp) -> None:
+                try:
+                    if resp.status == 403:
+                        self._save_debug(page, debug_dir=debug_dir, name_prefix="access_denied_403_response")
+                except Exception:
+                    pass
+
+            page.on("response", _on_response)
+
             page.goto(self.base_url, wait_until="domcontentloaded")
             self._wait_for_settle(page)
             self._step(page, debug_dir=debug_dir, name="after_goto")
@@ -1494,6 +1677,35 @@ class ServicerPortalClient:
 
         return False
 
+    def _looks_like_access_denied(self, page: Page) -> bool:
+        """
+        Detect HTTP 403 / Access Denied responses that some servicer portals return
+        when anti-automation detection fires (especially in headless mode).
+        """
+        try:
+            body = (page.inner_text("body") or "").strip()
+            if not body or len(body) > 500:
+                return False
+            low = body.lower()
+            if "403" in low and "access denied" in low:
+                return True
+            if "access denied" in low and len(body) < 100:
+                return True
+        except Exception:
+            pass
+        return False
+
+    def _raise_if_access_denied(self, page: Page, *, debug_dir: str) -> None:
+        if self._looks_like_access_denied(page):
+            self._save_debug(page, debug_dir=debug_dir, name_prefix="access_denied_403")
+            raise PortalAccessDeniedError(
+                "The servicer portal returned HTTP 403 (Access Denied). This is typically caused by "
+                "anti-automation detection in headless mode. Remediation steps:\n"
+                "  1. Try running with --headful --manual-mfa to establish a trusted session first.\n"
+                "  2. If the issue persists, try --fresh-session to clear stale cookies.\n"
+                "  3. Ensure you are not running from a datacenter IP with poor reputation.\n"
+                "See https://github.com/mattebad/monarch-studentaid-sync/issues/9 for discussion."
+            )
     def _extract_loans(
         self,
         page: Page,

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -15,6 +15,15 @@ def _client() -> ServicerPortalClient:
     )
 
 
+class _BodyOnlyPage:
+    def __init__(self, body_text: str) -> None:
+        self._body_text = body_text
+
+    def inner_text(self, selector: str) -> str:
+        assert selector == "body"
+        return self._body_text
+
+
 def test_parse_us_date_basic() -> None:
     assert parse_us_date("12/26/2025") == date(2025, 12, 26)
 
@@ -221,6 +230,8 @@ def test_non_posted_detection_mixed_statuses() -> None:
     assert got[date(2026, 2, 15)] == "processing"
     assert got[date(2026, 2, 1)] == "cancelled"
     assert date(2026, 1, 15) not in got
+
+
 def test_payment_history_list_detection_matches_table_view() -> None:
     c = _client()
     body = """
@@ -263,3 +274,21 @@ def test_payment_detail_context_detection_accepts_group_breakdown_text() -> None
     """.strip()
 
     assert c._looks_like_payment_detail_context(body, expected_groups={"AA", "AB"}) is True
+
+
+def test_looks_like_access_denied_matches_403_text() -> None:
+    c = _client()
+    page = _BodyOnlyPage("HTTP 403 Access denied.")
+    assert c._looks_like_access_denied(page) is True
+
+
+def test_looks_like_access_denied_matches_short_access_denied_text() -> None:
+    c = _client()
+    page = _BodyOnlyPage("Access denied")
+    assert c._looks_like_access_denied(page) is True
+
+
+def test_looks_like_access_denied_ignores_normal_page_content() -> None:
+    c = _client()
+    page = _BodyOnlyPage("Welcome back. Payment Activity is ready.")
+    assert c._looks_like_access_denied(page) is False

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -221,8 +221,6 @@ def test_non_posted_detection_mixed_statuses() -> None:
     assert got[date(2026, 2, 15)] == "processing"
     assert got[date(2026, 2, 1)] == "cancelled"
     assert date(2026, 1, 15) not in got
-
-
 def test_payment_history_list_detection_matches_table_view() -> None:
     c = _client()
     body = """


### PR DESCRIPTION
By default we now also use playwright tweaks to assist in remediating troublesome 403 errors during headless usage.