### PR TITLE
fix: add Monarch cookie bootstrap and saved-session auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ At a high level, each scheduled run:
 
 #### Prereqs (set these up once) ✅
 - **Monarch auth** (choose one):
-  - **Email/password**: set `MONARCH_EMAIL` + `MONARCH_PASSWORD`
-    - If you currently use **Google** / “**Continue with Google**” to access Monarch, you’ll need to **set a password** to use the API client (Monarch → **Settings → Security**).
-  - **Sign in with Apple / Google (token-based)**: set `MONARCH_TOKEN` (recommended for SSO). If you need help extracting it, see [Getting `MONARCH_TOKEN`](#monarch-token).
+  - **Cookie auth (preferred)**: run `bootstrap-monarch-auth` once to save `data/monarch_session.pickle` from a browser login, or set `MONARCH_COOKIE_STRING` to `session_id=...; csrftoken=...`.
+    - If you prefer split env vars, set `MONARCH_COOKIE_SESSION_ID` + `MONARCH_COOKIE_CSRFTOKEN`.
+  - **Email/password option**: set `MONARCH_EMAIL` + `MONARCH_PASSWORD` if your Monarch account uses password login.
+    - If you currently use **Google** / “**Continue with Google**” to access Monarch, you’ll need to **set a password** in Monarch → **Settings → Security** first.
+- The first successful Monarch login writes `data/monarch_session.pickle`; later runs reuse that saved session until it expires.
+  - To test the saved-session path by itself, temporarily clear `MONARCH_COOKIE_STRING` and `MONARCH_COOKIE_SESSION_ID` / `MONARCH_COOKIE_CSRFTOKEN` from `.env`, then run `preflight` or `sync --dry-run --dry-run-check-monarch`.
 - **Gmail IMAP for MFA**
   - You’ll need **IMAP enabled** + **2‑Step Verification** + a **Google App Password**.
   - If you want the step-by-step Gmail label/filter setup (recommended), see [Gmail IMAP setup](#gmail-imap-setup) 🏷️
@@ -38,7 +41,7 @@ Copy `env.example` → `.env` and fill in values (Monarch + Gmail IMAP + your lo
 Required:
 - `SERVICER_PROVIDER`, `SERVICER_USERNAME`, `SERVICER_PASSWORD`
 - `LOAN_GROUPS` (comma-separated: `AA,AB,...` or `1-01,1-02,...`)
-- Monarch auth (`MONARCH_TOKEN` or `MONARCH_EMAIL` + `MONARCH_PASSWORD`)
+- Monarch auth (`MONARCH_COOKIE_STRING`, split cookie vars, or `MONARCH_EMAIL` + `MONARCH_PASSWORD`)
 - Gmail IMAP (`GMAIL_IMAP_USER` + `GMAIL_IMAP_APP_PASSWORD`)
 
 Advanced (optional):
@@ -100,13 +103,19 @@ mkdir data
 docker compose run --rm --build studentaid-monarch-sync preflight
 ```
 
-4. Dry-run:
+4. Dry-run only:
 
 ```bash
 docker compose run --rm studentaid-monarch-sync sync --dry-run --payments-since 2025-01-01
 ```
 
-5. Run for real (writes to Monarch):
+5. Dry-run + read-only Monarch duplicate check:
+
+```bash
+docker compose run --rm studentaid-monarch-sync sync --dry-run --dry-run-check-monarch --payments-since 2025-01-01
+```
+
+6. Run for real (writes to Monarch):
 
 ```bash
 docker compose run --rm studentaid-monarch-sync sync --payments-since 2025-01-01
@@ -166,6 +175,8 @@ cd /path/to/repo && bash ./scripts/docker_sync.sh run --payments-since 2025-01-0
 Keep `./data` persistent so sessions and the SQLite idempotency DB survive restarts.
 
 #### Runtime B: Python (desktop/server) 🐍
+Requires Python 3.10+ now, because the updated Monarch dependency needs it.
+
 **Install**
 
 - **Windows**:
@@ -202,6 +213,12 @@ python3 -m venv .venv
 
 ```bash
 .venv\Scripts\python -m studentaid_monarch_sync sync --dry-run --headful
+```
+
+**Dry-run + read-only Monarch check**
+
+```bash
+.venv\Scripts\python -m studentaid_monarch_sync sync --dry-run --dry-run-check-monarch --headful --payments-since 2025-01-01 --max-payments 1
 ```
 
 **Run for real (writes to Monarch) ✅**
@@ -329,9 +346,10 @@ See **Quick start → Runtime A: Docker (recommended)** for the Unraid schedulin
   - Even if SQLite is lost, the Monarch-side duplicate guard (**date + amount + merchant**) prevents duplicate payment transactions.
 
 ### Troubleshooting (common friction)
-- **Monarch preflight failed / token expired**
-  - Re-login / refresh `MONARCH_TOKEN`.
-  - If a stale session is stuck, delete `data/monarch_session.pickle` and retry preflight.
+- **Monarch auth failed / 401**
+  - Re-copy `MONARCH_COOKIE_STRING` from an authenticated Monarch browser request.
+  - If `data/monarch_session.pickle` is stale, delete it and retry preflight.
+  - If you want a quick read-only check before a real run, use `sync --dry-run --dry-run-check-monarch`.
 - **MFA email not found**
   - Confirm Gmail IMAP is enabled and `GMAIL_IMAP_FOLDER` matches the label name.
   - Set broad hints: `GMAIL_IMAP_SENDER_HINT=studentaid.gov` and `GMAIL_IMAP_SUBJECT_HINT=code`.
@@ -352,15 +370,25 @@ See **Quick start → Runtime A: Docker (recommended)** for the Unraid schedulin
   - If your existing loan-account payments show up as **US Department of Education**, set this to that (recommended).
 - `monarch.duplicate_guard_use_reference` / `MONARCH_DUPLICATE_GUARD_USE_REFERENCE` (optional): when the portal provides a payment confirmation/reference, use it as a Monarch search term during duplicate detection to reduce false positives for same-day identical payments.
 
-<a id="monarch-token"></a>
-### Getting `MONARCH_TOKEN` (token-based auth for SSO)
-This works well for **Sign in with Apple** and **Continue with Google** flows, where password-based API login can be confusing.
+<a id="monarch-cookie-string"></a>
+### Getting `MONARCH_COOKIE_STRING` (browser-cookie auth)
+This is the most reliable way to bootstrap Monarch auth now.
 
-1. Log into Monarch in your browser normally (Apple/Google/etc).
+If you do not want to copy cookie values at all, run:
+
+```bash
+.venv/bin/python -m studentaid_monarch_sync bootstrap-monarch-auth
+```
+
+It opens Monarch in a browser, waits for you to log in once, then saves a reusable `data/monarch_session.pickle`.
+
+1. Log into Monarch in your browser normally.
 2. Open DevTools → **Network** tab.
-3. Click any request to Monarch’s API (often `graphql`).
-4. In **Request Headers**, copy the value after `Authorization: Token ...`.
-5. Put that into `.env` as `MONARCH_TOKEN=...` (keep it secret).
+3. Click any authenticated request to Monarch’s API (often `graphql`).
+4. In **Request Headers**, copy the cookie value after `Cookie:`. Do **not** include the `Cookie:` label itself.
+5. Minimum needed cookies are `session_id` and `csrftoken`. Extra cookies like `cf_clearance`, `__cf_bm`, `ajs_*`, and `osano_*` are not used by this project.
+6. Put the copied cookie string into `.env` as `MONARCH_COOKIE_STRING=session_id=...; csrftoken=...` (keep it secret).
+   - Or split them: `MONARCH_COOKIE_SESSION_ID=...` + `MONARCH_COOKIE_CSRFTOKEN=...`
 
 ### CLI flags (reference)
 Run `-h` at any time to see the full help:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -23,9 +23,11 @@ gmail_imap:
   code_regex: "\\b(\\d{6})\\b"
 
 monarch:
+  cookie_string: "${MONARCH_COOKIE_STRING}"
+  cookie_session_id: "${MONARCH_COOKIE_SESSION_ID}"
+  cookie_csrftoken: "${MONARCH_COOKIE_CSRFTOKEN}"
   email: "${MONARCH_EMAIL}"
   password: "${MONARCH_PASSWORD}"
-  token: "${MONARCH_TOKEN}"
   mfa_secret: "${MONARCH_MFA_SECRET}"
   transfer_category_name: "Transfer"
   # Merchant name to use for payment transactions (also used by dupe-check: date + amount + merchant)

--- a/env.example
+++ b/env.example
@@ -31,11 +31,17 @@ GMAIL_IMAP_SENDER_HINT=studentaid.gov
 GMAIL_IMAP_SUBJECT_HINT=code
 
 # --- Monarch credentials ---
+# Preferred: one-time bootstrap with `bootstrap-monarch-auth` saves a session file automatically.
+# After bootstrap, you can leave these blank; the saved session is tried first.
+# Manual copy/paste option: cookie value copied from an authenticated Monarch browser request.
+# Copy the value after `Cookie:`. Minimum needed cookies: `session_id` + `csrftoken`.
+MONARCH_COOKIE_STRING=
+# Optional split option if you prefer separate vars.
+MONARCH_COOKIE_SESSION_ID=
+MONARCH_COOKIE_CSRFTOKEN=
+# If you use Monarch password login, fill these in too.
 MONARCH_EMAIL=
-# If you use "Sign in with Apple" and don't have a Monarch password, prefer MONARCH_TOKEN.
 MONARCH_PASSWORD=
-# Preferred for "Sign in with Apple": grab from browser request header "Authorization: Token <...>"
-MONARCH_TOKEN=
 # If Monarch uses authenticator-app TOTP, set this to the TOTP secret.
 MONARCH_MFA_SECRET=
 

--- a/portal.env.example
+++ b/portal.env.example
@@ -34,10 +34,16 @@ GMAIL_IMAP_SENDER_HINT=studentaid.gov
 GMAIL_IMAP_SUBJECT_HINT=code
 
 # --- Monarch credentials ---
-# Use either MONARCH_TOKEN (preferred) OR email/password.
+# Preferred: run `bootstrap-monarch-auth` once so you do not need to copy cookies manually.
+# After bootstrap, you can leave these blank; the saved session is tried first.
+# Manual copy/paste option: full Cookie header copied from an authenticated Monarch browser request.
+MONARCH_COOKIE_STRING=
+# Optional split option if you prefer separate vars.
+MONARCH_COOKIE_SESSION_ID=
+MONARCH_COOKIE_CSRFTOKEN=
+# Keep these only if you use Monarch password login.
 MONARCH_EMAIL=
 MONARCH_PASSWORD=
-MONARCH_TOKEN=
 MONARCH_MFA_SECRET=
 
 MONARCH_DUPLICATE_GUARD_USE_REFERENCE=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "studentaid-monarch-sync"
 version = "0.1.0"
 description = "Sync StudentAid servicer loan balances + posted payments into Monarch Money"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ requests==2.32.3
 
 # Monarch API client (unofficial).
 # NOTE: The original `hammem/monarchmoney` project is unmaintained and uses the old Monarch domain.
-# This maintained fork includes fixes for the domain change to `api.monarch.com`.
-monarchmoneycommunity==1.1.0
+# This maintained fork includes fixes for the domain change to `api.monarch.com` and cookie-based auth.
+monarchmoneycommunity==1.4.0
 
 # Tests (fast, no secrets)
 pytest==8.3.4

--- a/scripts/docker_sync.sh
+++ b/scripts/docker_sync.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #   ./scripts/docker_sync.sh setup-accounts
 #   ./scripts/docker_sync.sh preflight
 #   ./scripts/docker_sync.sh dry-run --payments-since 2025-01-01
+#   ./scripts/docker_sync.sh dry-run --dry-run-check-monarch --payments-since 2025-01-01
 #   ./scripts/docker_sync.sh run --payments-since 2025-01-01
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/src/studentaid_monarch_sync/cli.py
+++ b/src/studentaid_monarch_sync/cli.py
@@ -37,6 +37,17 @@ from .util.money import cents_to_money_str
 logger = logging.getLogger("studentaid_monarch_sync")
 
 
+def _build_monarch_client(cfg) -> MonarchClient:
+    return MonarchClient(
+        email=cfg.monarch.email,
+        password=cfg.monarch.password,
+        cookie_string=cfg.monarch.cookie_string,
+        token=cfg.monarch.token,
+        mfa_secret=cfg.monarch.mfa_secret,
+        session_file=cfg.monarch.session_file,
+    )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="studentaid_monarch_sync")
     p.add_argument(
@@ -150,6 +161,21 @@ def _build_parser() -> argparse.ArgumentParser:
         "--out",
         default="",
         help="Optional output path for the mapping JSON (default: data/monarch_loan_accounts_{provider}.json)",
+    )
+
+    bootstrap = sub.add_parser(
+        "bootstrap-monarch-auth",
+        help="Open Monarch in a browser, let you log in once, and save a reusable Monarch session.",
+    )
+    bootstrap.add_argument(
+        "--url",
+        default="https://app.monarchmoney.com",
+        help="Monarch login/start URL to open (default: https://app.monarchmoney.com)",
+    )
+    bootstrap.add_argument(
+        "--out",
+        default="",
+        help="Path to save the Monarch session pickle (default: MONARCH_SESSION_FILE or data/monarch_session.pickle)",
     )
 
     list_servicers = sub.add_parser(
@@ -413,6 +439,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         )
         return 0
 
+    if args.cmd == "bootstrap-monarch-auth":
+        configure_logging(level=os.getenv("LOG_LEVEL", "INFO"))
+        out_path = args.out or os.getenv("MONARCH_SESSION_FILE", "data/monarch_session.pickle")
+        asyncio.run(_bootstrap_monarch_auth(login_url=args.url, out_path=out_path))
+        return 0
+
     if args.cmd == "list-loan-groups":
         cfg = load_config(args.config)
         configure_logging(level=cfg.logging.level, file_path=cfg.logging.file_path)
@@ -523,27 +555,30 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 def _require_monarch_auth(cfg) -> None:
     m = cfg.monarch
+    if getattr(m, "cookie_string", ""):
+        return
     if getattr(m, "token", ""):
         return
     if getattr(m, "email", "") and getattr(m, "password", ""):
         return
-    raise SystemExit("Missing Monarch auth. Set MONARCH_TOKEN or MONARCH_EMAIL + MONARCH_PASSWORD in your .env.")
+    session_file = Path(getattr(m, "session_file", "") or "")
+    if session_file.exists():
+        return
+    raise SystemExit(
+        "Missing Monarch auth. Use bootstrap-monarch-auth once, set MONARCH_COOKIE_STRING or split cookie vars "
+        "(MONARCH_COOKIE_SESSION_ID + MONARCH_COOKIE_CSRFTOKEN), or use MONARCH_EMAIL + MONARCH_PASSWORD. "
+        "An existing data/monarch_session.pickle also works."
+    )
 
 
 async def _preflight_monarch(cfg, *, check_mappings: bool = True) -> None:
     """
     Validate Monarch auth and basic config mapping without mutating anything.
 
-    This is deliberately lightweight: it catches invalid/expired tokens and bad account/category mappings
+    This is deliberately lightweight: it catches invalid/expired Monarch cookies/sessions and bad account/category mappings
     before we spend time logging into the StudentAid portal.
     """
-    mc = MonarchClient(
-        email=cfg.monarch.email,
-        password=cfg.monarch.password,
-        token=cfg.monarch.token,
-        mfa_secret=cfg.monarch.mfa_secret,
-        session_file=cfg.monarch.session_file,
-    )
+    mc = _build_monarch_client(cfg)
 
     try:
         await mc.login()
@@ -563,9 +598,10 @@ async def _preflight_monarch(cfg, *, check_mappings: bool = True) -> None:
         logger.info("Monarch preflight OK (accounts=%d, transfer_category=%r)", len(accounts), cfg.monarch.transfer_category_name)
     except Exception as e:
         raise RuntimeError(
-            "Monarch preflight failed. This often means your MONARCH_TOKEN/session is invalid/expired, "
-            "or your loan account mappings are missing/wrong. Fix Monarch auth (or delete data/monarch_session.pickle), "
-            "then run `studentaid_monarch_sync setup-monarch-accounts --apply` to auto-create/map accounts."
+            "Monarch preflight failed. This often means your MONARCH_COOKIE_STRING is invalid/expired, "
+            "or split cookie vars are wrong, or data/monarch_session.pickle is stale, or your loan account mappings are missing/wrong. "
+            "Delete the session pickle, rerun bootstrap-monarch-auth or refresh cookie vars, then rerun `studentaid_monarch_sync preflight` "
+            "and `studentaid_monarch_sync setup-monarch-accounts --apply` if mappings still need setup."
         ) from e
 
 
@@ -598,6 +634,68 @@ def _preflight_gmail_imap(cfg) -> None:
         raise RuntimeError(
             "Gmail IMAP preflight failed. Check GMAIL_IMAP_USER/GMAIL_IMAP_APP_PASSWORD and folder/label configuration."
         ) from e
+
+
+def _build_monarch_cookie_string(*, session_id: str, csrftoken: str) -> str:
+    sid = (session_id or "").strip()
+    csrf = (csrftoken or "").strip()
+    if not sid or not csrf:
+        raise ValueError("Both session_id and csrftoken are required.")
+    return f"session_id={sid}; csrftoken={csrf}"
+
+
+async def _bootstrap_monarch_auth(*, login_url: str, out_path: str) -> None:
+    """
+    Open Monarch in a browser, let the user complete a login, and save a reusable Monarch session.
+
+    This avoids manual copy/paste of cookie values for first-time setup.
+    """
+    from monarchmoney import MonarchMoney
+    from playwright.async_api import async_playwright
+
+    logger.info("Opening Monarch browser at %s", login_url)
+    logger.info("Log in manually, then come back here and press Enter to capture cookies.")
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=False)
+        context = await browser.new_context()
+        page = await context.new_page()
+        try:
+            await page.goto(login_url, wait_until="domcontentloaded")
+            input("Press Enter after Monarch login is complete...")
+
+            cookies = await context.cookies()
+            cookie_map = {
+                str(c.get("name") or ""): str(c.get("value") or "")
+                for c in cookies
+                if str(c.get("name") or "") in {"session_id", "csrftoken"}
+            }
+
+            if "session_id" not in cookie_map or "csrftoken" not in cookie_map:
+                found = ", ".join(sorted({str(c.get("name") or "") for c in cookies if c.get("name")}))
+                raise RuntimeError(
+                    "Could not find session_id + csrftoken after login. "
+                    f"Cookies seen: {found or '(none)'}"
+                )
+
+            cookie_string = _build_monarch_cookie_string(
+                session_id=cookie_map["session_id"],
+                csrftoken=cookie_map["csrftoken"],
+            )
+
+            mm = MonarchMoney(session_file=out_path)
+            await mm.login_with_cookies(cookie_string, save_session=True, verify=True)
+            logger.info("Bootstrap complete. Saved Monarch session to %s", out_path)
+            print(f"✅ Saved Monarch session: {out_path}")
+        finally:
+            try:
+                await context.close()
+            except Exception:
+                pass
+            try:
+                await browser.close()
+            except Exception:
+                pass
 
 
 def _log_dry_run(cfg, state: StateStore, loan_snapshots, payment_allocations) -> None:
@@ -639,13 +737,7 @@ async def _log_dry_run_with_monarch(cfg, state: StateStore, loan_snapshots, paym
     """
     from datetime import date as _date
 
-    mc = MonarchClient(
-        email=cfg.monarch.email,
-        password=cfg.monarch.password,
-        token=cfg.monarch.token,
-        mfa_secret=cfg.monarch.mfa_secret,
-        session_file=cfg.monarch.session_file,
-    )
+    mc = _build_monarch_client(cfg)
     await mc.login()
 
     transfer_category_id = await mc.get_category_id_by_name(cfg.monarch.transfer_category_name)
@@ -762,13 +854,7 @@ async def _log_dry_run_with_monarch(cfg, state: StateStore, loan_snapshots, paym
 
 
 async def _list_monarch_accounts(cfg) -> None:
-    mc = MonarchClient(
-        email=cfg.monarch.email,
-        password=cfg.monarch.password,
-        token=cfg.monarch.token,
-        mfa_secret=cfg.monarch.mfa_secret,
-        session_file=cfg.monarch.session_file,
-    )
+    mc = _build_monarch_client(cfg)
     await mc.login()
     accounts = await mc.list_accounts()
 
@@ -997,13 +1083,7 @@ async def _setup_monarch_accounts(
     if not template:
         template = DEFAULT_LOAN_ACCOUNT_NAME_TEMPLATE
 
-    mc = MonarchClient(
-        email=cfg.monarch.email,
-        password=cfg.monarch.password,
-        token=cfg.monarch.token,
-        mfa_secret=cfg.monarch.mfa_secret,
-        session_file=cfg.monarch.session_file,
-    )
+    mc = _build_monarch_client(cfg)
     await mc.login()
 
     if not apply:
@@ -1068,13 +1148,7 @@ async def _apply_monarch_updates(
 ) -> None:
     from datetime import date as _date
 
-    mc = MonarchClient(
-        email=cfg.monarch.email,
-        password=cfg.monarch.password,
-        token=cfg.monarch.token,
-        mfa_secret=cfg.monarch.mfa_secret,
-        session_file=cfg.monarch.session_file,
-    )
+    mc = _build_monarch_client(cfg)
     await mc.login()
 
     transfer_category_id = await mc.get_category_id_by_name(cfg.monarch.transfer_category_name)

--- a/src/studentaid_monarch_sync/config.py
+++ b/src/studentaid_monarch_sync/config.py
@@ -140,6 +140,9 @@ def _default_config_from_env() -> dict:
         "monarch": {
             "email": os.getenv("MONARCH_EMAIL", ""),
             "password": os.getenv("MONARCH_PASSWORD", ""),
+            "cookie_string": os.getenv("MONARCH_COOKIE_STRING", ""),
+            "cookie_session_id": os.getenv("MONARCH_COOKIE_SESSION_ID", ""),
+            "cookie_csrftoken": os.getenv("MONARCH_COOKIE_CSRFTOKEN", ""),
             "token": os.getenv("MONARCH_TOKEN", ""),
             "mfa_secret": os.getenv("MONARCH_MFA_SECRET", ""),
             "transfer_category_name": os.getenv("MONARCH_TRANSFER_CATEGORY_NAME", "Transfer"),
@@ -215,10 +218,16 @@ class GmailImapConfig(BaseModel):
 
 
 class MonarchConfig(BaseModel):
-    # If you use "Sign in with Apple", prefer token-based auth.
+    # Preferred Monarch auth now: full browser cookie string copied from DevTools.
+    cookie_string: str = Field(default="", repr=False)
+    # Split vars for users who prefer to paste session_id and csrftoken separately.
+    cookie_session_id: str = Field(default="", repr=False)
+    cookie_csrftoken: str = Field(default="", repr=False)
+
+    # Compatibility token path for installs that still work with token auth.
     token: str = Field(default="", repr=False)
 
-    # Email/password auth (optional if token is set)
+    # Email/password auth for Monarch accounts that still use password login.
     email: str = ""
     password: str = Field(default="", repr=False)
     mfa_secret: str = Field(default="", repr=False)
@@ -243,6 +252,10 @@ class MonarchConfig(BaseModel):
         # Some commands (e.g. `list-loan-groups`) only need portal access.
         #
         # Commands that require Monarch will validate auth explicitly and raise a clear error.
+        has_session = bool((self.cookie_session_id or "").strip())
+        has_csrf = bool((self.cookie_csrftoken or "").strip())
+        if not self.cookie_string and has_session and has_csrf:
+            self.cookie_string = f"session_id={self.cookie_session_id.strip()}; csrftoken={self.cookie_csrftoken.strip()}"
         return self
 
 

--- a/src/studentaid_monarch_sync/monarch/client.py
+++ b/src/studentaid_monarch_sync/monarch/client.py
@@ -10,6 +10,12 @@ from typing import Optional, List, Dict, Any, Tuple, Callable, Awaitable, TypeVa
 
 from monarchmoney import MonarchMoney
 
+try:
+    from monarchmoney import CaptchaRequiredException
+except ImportError:  # pragma: no cover - compatibility with older monarchmoneycommunity builds
+    class CaptchaRequiredException(Exception):
+        pass
+
 from ..util.money import cents_to_money_str
 
 
@@ -50,22 +56,24 @@ class MonarchClient:
         *,
         email: str,
         password: str,
+        cookie_string: str,
         token: str,
         mfa_secret: str,
         session_file: str,
     ) -> None:
         self._email = email
         self._password = password
+        self._cookie_string = cookie_string.strip() if cookie_string else ""
         self._token = token.strip() if token else ""
         self._mfa_secret = mfa_secret or None
         self._session_file = session_file
-        self._mm = MonarchMoney(session_file=session_file, token=self._token or None)
 
         self._accounts_cache: Optional[List[Dict[str, Any]]] = None
         self._account_type_options_cache: Optional[List[Dict[str, Any]]] = None
         self._category_cache: Optional[List[Dict[str, Any]]] = None
         self._transactions_cache: dict[tuple[str, str, str, int, int, str], List[Dict[str, Any]]] = {}
         self._student_loan_type_subtype: Optional[Tuple[str, str]] = None
+        self._reset_client()
 
     async def _call_with_retry(self, op: str, fn: Callable[[], Awaitable[T]]) -> T:
         """
@@ -126,35 +134,89 @@ class MonarchClient:
         for k in doomed:
             self._transactions_cache.pop(k, None)
 
+    def _reset_client(self, *, include_token: bool = True) -> None:
+        self._mm = MonarchMoney(session_file=self._session_file, token=self._token if include_token and self._token else None)
+        self._accounts_cache = None
+        self._account_type_options_cache = None
+        self._category_cache = None
+        self._transactions_cache = {}
+        self._student_loan_type_subtype = None
+
     async def login(self) -> None:
         # Ensure the session directory exists (important for commands like list-monarch-accounts).
         session_path = Path(self._session_file)
         session_path.parent.mkdir(parents=True, exist_ok=True)
+        last_exc: Optional[BaseException] = None
 
-        # 1) If we have a saved session token, use it (works with Sign in with Apple).
+        # Start from a clean client so stale auth mode/cookies from a prior attempt do not leak into other paths.
+        self._reset_client()
+
+        # 1) If we have a saved session, use it first.
         if session_path.exists():
             try:
                 self._mm.load_session(str(session_path))
+                await self._mm.get_accounts()
                 return
-            except Exception:
+            except Exception as e:
                 logger.warning("Failed to load saved Monarch session; will re-authenticate.", exc_info=True)
+                last_exc = e
                 try:
                     session_path.unlink()
                 except Exception:
                     logger.debug("Failed to delete invalid Monarch session file.", exc_info=True)
+                self._reset_client()
 
-        # 2) If caller provided a token, use it and persist it.
+        # 2) Browser-cookie bootstrap from Monarch web session.
+        if self._cookie_string:
+            try:
+                await self._mm.login_with_cookies(self._cookie_string, save_session=True, verify=True)
+                return
+            except Exception as e:
+                logger.warning("Monarch cookie auth failed; will try token or password login if configured.", exc_info=True)
+                last_exc = e
+                self._reset_client()
+
+        # 3) Compatibility token path. Keep only for installs that still work with token auth.
         if self._token:
-            self._mm.save_session(str(session_path))
-            return
+            try:
+                await self._mm.get_accounts()
+                self._mm.save_session(str(session_path))
+                return
+            except Exception as e:
+                logger.warning("Monarch token auth failed; will try password login if configured.", exc_info=True)
+                last_exc = e
+                self._reset_client(include_token=False)
 
-        # 3) Fall back to email/password login.
-        await self._mm.login(
-            email=self._email,
-            password=self._password,
-            use_saved_session=True,
-            save_session=True,
-            mfa_secret_key=self._mfa_secret,
+        # 4) Fall back to email/password login.
+        if self._email and self._password:
+            try:
+                await self._mm.login(
+                    email=self._email,
+                    password=self._password,
+                    use_saved_session=False,
+                    save_session=True,
+                    mfa_secret_key=self._mfa_secret,
+                )
+                return
+            except CaptchaRequiredException as e:
+                raise RuntimeError(
+                    "Monarch login blocked by CAPTCHA. Use bootstrap-monarch-auth in a browser or export "
+                    "MONARCH_COOKIE_STRING / split cookie vars from an authenticated Monarch request, delete stale "
+                    "data/monarch_session.pickle, then rerun."
+                ) from e
+            except Exception as e:
+                logger.warning("Monarch email/password auth failed.", exc_info=True)
+                last_exc = e
+
+        if last_exc is not None:
+            raise RuntimeError(
+                "Monarch auth failed. Delete stale data/monarch_session.pickle, rerun bootstrap-monarch-auth, or "
+                "refresh MONARCH_COOKIE_STRING / split cookie vars from an authenticated browser session, then rerun."
+            ) from last_exc
+
+        raise RuntimeError(
+            "Missing Monarch auth. Use bootstrap-monarch-auth once, set MONARCH_COOKIE_STRING or split cookie vars, "
+            "or set MONARCH_EMAIL + MONARCH_PASSWORD in your .env. An existing data/monarch_session.pickle also works."
         )
 
     async def list_accounts(self) -> List[Dict[str, Any]]:

--- a/tests/test_cli_bootstrap_monarch_auth.py
+++ b/tests/test_cli_bootstrap_monarch_auth.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import builtins
+import sys
+import types
+from pathlib import Path
+
+from studentaid_monarch_sync.cli import _bootstrap_monarch_auth
+
+
+class _FakePage:
+    def __init__(self) -> None:
+        self.goto_calls: list[tuple[str, str]] = []
+
+    async def goto(self, url: str, wait_until: str) -> None:
+        self.goto_calls.append((url, wait_until))
+
+
+class _FakeContext:
+    def __init__(self) -> None:
+        self.page = _FakePage()
+        self.closed = False
+
+    async def new_page(self) -> _FakePage:
+        return self.page
+
+    async def cookies(self) -> list[dict[str, str]]:
+        return [
+            {"name": "session_id", "value": "abc"},
+            {"name": "csrftoken", "value": "def"},
+            {"name": "extra_cookie", "value": "ignored"},
+        ]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeBrowser:
+    def __init__(self) -> None:
+        self.context = _FakeContext()
+        self.closed = False
+        self.launch_calls: list[dict[str, object]] = []
+
+    async def new_context(self) -> _FakeContext:
+        return self.context
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeChromium:
+    def __init__(self) -> None:
+        self.browser = _FakeBrowser()
+        self.calls: list[dict[str, object]] = []
+
+    async def launch(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return self.browser
+
+
+class _FakeAsyncPlaywright:
+    def __init__(self, chromium: _FakeChromium) -> None:
+        self.chromium = chromium
+
+    async def __aenter__(self):
+        return types.SimpleNamespace(chromium=self.chromium)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeMonarchMoney:
+    instances: list["_FakeMonarchMoney"] = []
+
+    def __init__(self, session_file: str) -> None:
+        self.session_file = session_file
+        self.login_calls: list[dict[str, object]] = []
+        self.__class__.instances.append(self)
+
+    async def login_with_cookies(self, cookie_string: str, **kwargs) -> None:
+        self.login_calls.append({"cookie_string": cookie_string, **kwargs})
+        Path(self.session_file).write_text("saved-session", encoding="utf-8")
+
+
+def test_bootstrap_monarch_auth_saves_session(monkeypatch, tmp_path, capsys) -> None:
+    chromium = _FakeChromium()
+    _FakeMonarchMoney.instances = []
+
+    fake_playwright_mod = types.ModuleType("playwright.async_api")
+
+    def async_playwright():
+        return _FakeAsyncPlaywright(chromium)
+
+    fake_playwright_mod.async_playwright = async_playwright
+    fake_playwright_pkg = types.ModuleType("playwright")
+    fake_playwright_pkg.__path__ = []  # mark as package
+    fake_monarch_mod = types.ModuleType("monarchmoney")
+    fake_monarch_mod.MonarchMoney = _FakeMonarchMoney
+
+    monkeypatch.setitem(sys.modules, "playwright", fake_playwright_pkg)
+    monkeypatch.setitem(sys.modules, "playwright.async_api", fake_playwright_mod)
+    monkeypatch.setitem(sys.modules, "monarchmoney", fake_monarch_mod)
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "")
+
+    out_path = tmp_path / "monarch_session.pickle"
+
+    # `input()` is stubbed, so the flow runs end-to-end without manual interaction.
+    import asyncio
+
+    asyncio.run(_bootstrap_monarch_auth(login_url="https://app.monarchmoney.com", out_path=str(out_path)))
+
+    assert chromium.calls == [{"headless": False}]
+    assert chromium.browser.context.page.goto_calls == [("https://app.monarchmoney.com", "domcontentloaded")]
+    assert _FakeMonarchMoney.instances[0].login_calls == [
+        {
+            "cookie_string": "session_id=abc; csrftoken=def",
+            "save_session": True,
+            "verify": True,
+        }
+    ]
+    assert out_path.read_text(encoding="utf-8") == "saved-session"
+
+    stdout = capsys.readouterr().out
+    assert "Saved Monarch session" in stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from studentaid_monarch_sync.cli import _build_monarch_cookie_string
 from studentaid_monarch_sync.config import _derive_provider_from_base_url, load_config
 
 
@@ -104,5 +105,38 @@ monarch:
     )
     with pytest.raises(Exception):
         _ = load_config(cfg_path)
+
+
+def test_monarch_cookie_string_comes_from_env(tmp_path: Path, monkeypatch) -> None:
+    cfg_path = tmp_path / "missing.yaml"
+
+    monkeypatch.setenv("SERVICER_PROVIDER", "nelnet")
+    monkeypatch.setenv("SERVICER_USERNAME", "u")
+    monkeypatch.setenv("SERVICER_PASSWORD", "p")
+    monkeypatch.setenv("GMAIL_IMAP_USER", "me@gmail.com")
+    monkeypatch.setenv("GMAIL_IMAP_APP_PASSWORD", "app-pass")
+    monkeypatch.setenv("MONARCH_COOKIE_STRING", "session_id=abc; csrftoken=def")
+
+    cfg = load_config(cfg_path)
+    assert cfg.monarch.cookie_string == "session_id=abc; csrftoken=def"
+
+
+def test_monarch_cookie_string_comes_from_split_env_vars(tmp_path: Path, monkeypatch) -> None:
+    cfg_path = tmp_path / "missing.yaml"
+
+    monkeypatch.setenv("SERVICER_PROVIDER", "nelnet")
+    monkeypatch.setenv("SERVICER_USERNAME", "u")
+    monkeypatch.setenv("SERVICER_PASSWORD", "p")
+    monkeypatch.setenv("GMAIL_IMAP_USER", "me@gmail.com")
+    monkeypatch.setenv("GMAIL_IMAP_APP_PASSWORD", "app-pass")
+    monkeypatch.setenv("MONARCH_COOKIE_SESSION_ID", "abc")
+    monkeypatch.setenv("MONARCH_COOKIE_CSRFTOKEN", "def")
+
+    cfg = load_config(cfg_path)
+    assert cfg.monarch.cookie_string == "session_id=abc; csrftoken=def"
+
+
+def test_build_monarch_cookie_string() -> None:
+    assert _build_monarch_cookie_string(session_id="abc", csrftoken="def") == "session_id=abc; csrftoken=def"
 
 

--- a/tests/test_loan_groups_env.py
+++ b/tests/test_loan_groups_env.py
@@ -12,7 +12,7 @@ def test_loan_groups_can_come_from_env(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("SERVICER_PASSWORD", "p")
     monkeypatch.setenv("GMAIL_IMAP_USER", "me@gmail.com")
     monkeypatch.setenv("GMAIL_IMAP_APP_PASSWORD", "app-pass")
-    monkeypatch.setenv("MONARCH_TOKEN", "dummy")
+    monkeypatch.setenv("MONARCH_COOKIE_STRING", "session_id=dummy; csrftoken=dummy")
     monkeypatch.setenv("LOAN_GROUPS", "AA, 1-01")
 
     cfg = load_config(cfg_path)
@@ -27,7 +27,7 @@ def test_invalid_loan_groups_warn_and_are_ignored(tmp_path, monkeypatch, caplog)
     monkeypatch.setenv("SERVICER_PASSWORD", "p")
     monkeypatch.setenv("GMAIL_IMAP_USER", "me@gmail.com")
     monkeypatch.setenv("GMAIL_IMAP_APP_PASSWORD", "app-pass")
-    monkeypatch.setenv("MONARCH_TOKEN", "dummy")
+    monkeypatch.setenv("MONARCH_COOKIE_STRING", "session_id=dummy; csrftoken=dummy")
     monkeypatch.setenv(
         "LOAN_GROUPS",
         "AA, ??, 1-01, 1_02, AB, , 123456789012345678901234567890123, A",

--- a/tests/test_monarch_client_cache.py
+++ b/tests/test_monarch_client_cache.py
@@ -5,6 +5,8 @@ import sys
 import types
 from typing import Any, Dict, List
 
+import pytest
+
 
 def _import_monarch_client_with_fake_dep(monkeypatch):
     """
@@ -14,7 +16,17 @@ def _import_monarch_client_with_fake_dep(monkeypatch):
     dedupe-on-create-error) without requiring the real Monarch client dependency.
     """
 
+    class FakeCaptchaRequiredException(Exception):
+        pass
+
     class FakeMonarchMoney:
+        load_session_error: Exception | None = None
+        login_error: Exception | None = None
+        login_with_cookies_error: Exception | None = None
+        get_accounts_error: Exception | None = None
+        instances: List["FakeMonarchMoney"] = []
+        CaptchaRequiredException = FakeCaptchaRequiredException
+
         def __init__(self, session_file: str, token: str | None = None) -> None:
             self.session_file = session_file
             self.token = token
@@ -23,19 +35,48 @@ def _import_monarch_client_with_fake_dep(monkeypatch):
             self.calls_get_transactions = 0
             self.fail_create_after_append = False
             self.fail_get_transactions_times = 0
+            self.loaded_session_paths: List[str] = []
+            self.saved_session_paths: List[str] = []
+            self.login_calls: List[Dict[str, Any]] = []
+            self.login_with_cookies_calls: List[Dict[str, Any]] = []
+            self.calls_get_accounts = 0
+            self.__class__.instances.append(self)
 
         # Session helpers used by MonarchClient.login()
         def load_session(self, _path: str) -> None:
+            self.loaded_session_paths.append(_path)
+            if self.__class__.load_session_error is not None:
+                raise self.__class__.load_session_error
             return None
 
         def save_session(self, _path: str) -> None:
+            self.saved_session_paths.append(_path)
             return None
 
         # Methods called by MonarchClient
         async def login(self, **_kwargs: Any) -> None:
+            self.login_calls.append(dict(_kwargs))
+            if self.__class__.login_error is not None:
+                raise self.__class__.login_error
+            if _kwargs.get("save_session", True):
+                self.save_session(self.session_file)
+            return None
+
+        async def login_with_cookies(self, cookie_string: str, **_kwargs: Any) -> None:
+            call = {"cookie_string": cookie_string, **_kwargs}
+            self.login_with_cookies_calls.append(call)
+            if self.__class__.login_with_cookies_error is not None:
+                raise self.__class__.login_with_cookies_error
+            if _kwargs.get("verify", True):
+                await self.get_accounts()
+            if _kwargs.get("save_session", True):
+                self.save_session(self.session_file)
             return None
 
         async def get_accounts(self) -> Dict[str, Any]:
+            self.calls_get_accounts += 1
+            if self.__class__.get_accounts_error is not None:
+                raise self.__class__.get_accounts_error
             return {"accounts": [{"id": "acct1", "displayBalance": 0, "displayName": "Loan-AA", "isManual": True}]}
 
         async def get_transaction_categories(self) -> Dict[str, Any]:
@@ -93,6 +134,7 @@ def _import_monarch_client_with_fake_dep(monkeypatch):
 
     fake_mod = types.ModuleType("monarchmoney")
     fake_mod.MonarchMoney = FakeMonarchMoney
+    fake_mod.CaptchaRequiredException = FakeCaptchaRequiredException
     monkeypatch.setitem(sys.modules, "monarchmoney", fake_mod)
 
     # Ensure the module imports fresh with our stub.
@@ -108,6 +150,7 @@ def test_create_payment_transaction_invalidates_transactions_cache(monkeypatch, 
     mc = MonarchClient(
         email="",
         password="",
+        cookie_string="",
         token="token",
         mfa_secret="",
         session_file=str(tmp_path / "monarch_session.pickle"),
@@ -158,6 +201,7 @@ def test_create_payment_transaction_recovers_on_timeout_by_duplicate_guard(monke
     mc = MonarchClient(
         email="",
         password="",
+        cookie_string="",
         token="token",
         mfa_secret="",
         session_file=str(tmp_path / "monarch_session.pickle"),
@@ -186,6 +230,7 @@ def test_find_duplicate_transaction_paginates(monkeypatch, tmp_path) -> None:
     mc = MonarchClient(
         email="",
         password="",
+        cookie_string="",
         token="token",
         mfa_secret="",
         session_file=str(tmp_path / "monarch_session.pickle"),
@@ -233,6 +278,7 @@ def test_list_transactions_retries_transient_failure(monkeypatch, tmp_path) -> N
     mc = MonarchClient(
         email="",
         password="",
+        cookie_string="",
         token="token",
         mfa_secret="",
         session_file=str(tmp_path / "monarch_session.pickle"),
@@ -259,6 +305,7 @@ def test_find_duplicate_transaction_respects_search(monkeypatch, tmp_path) -> No
     mc = MonarchClient(
         email="",
         password="",
+        cookie_string="",
         token="token",
         mfa_secret="",
         session_file=str(tmp_path / "monarch_session.pickle"),
@@ -298,5 +345,125 @@ def test_find_duplicate_transaction_respects_search(monkeypatch, tmp_path) -> No
     )
     assert dup is not None
     assert dup.get("id") == "t2"
+
+
+def test_login_prefers_saved_session_over_cookie_bootstrap(monkeypatch, tmp_path) -> None:
+    MonarchClient, FakeMonarchMoney = _import_monarch_client_with_fake_dep(monkeypatch)
+    session_file = tmp_path / "monarch_session.pickle"
+    session_file.write_text("placeholder", encoding="utf-8")
+
+    mc = MonarchClient(
+        email="",
+        password="",
+        cookie_string="session_id=cookie; csrftoken=csrf",
+        token="token",
+        mfa_secret="",
+        session_file=str(session_file),
+    )
+
+    asyncio.run(mc.login())
+
+    assert mc._mm.loaded_session_paths == [str(session_file)]
+    assert mc._mm.login_with_cookies_calls == []
+    assert mc._mm.login_calls == []
+    assert mc._mm.calls_get_accounts == 1
+
+
+def test_login_bootstraps_from_cookie_string(monkeypatch, tmp_path) -> None:
+    MonarchClient, FakeMonarchMoney = _import_monarch_client_with_fake_dep(monkeypatch)
+    session_file = tmp_path / "monarch_session.pickle"
+
+    mc = MonarchClient(
+        email="",
+        password="",
+        cookie_string="session_id=cookie; csrftoken=csrf",
+        token="token",
+        mfa_secret="",
+        session_file=str(session_file),
+    )
+
+    asyncio.run(mc.login())
+
+    assert mc._mm.loaded_session_paths == []
+    assert mc._mm.login_with_cookies_calls == [
+        {
+            "cookie_string": "session_id=cookie; csrftoken=csrf",
+            "save_session": True,
+            "verify": True,
+        }
+    ]
+    assert mc._mm.login_calls == []
+    assert mc._mm.calls_get_accounts == 1
+    assert mc._mm.saved_session_paths == [str(session_file)]
+
+
+def test_login_falls_back_from_stale_session_to_cookie_string(monkeypatch, tmp_path) -> None:
+    MonarchClient, FakeMonarchMoney = _import_monarch_client_with_fake_dep(monkeypatch)
+    FakeMonarchMoney.load_session_error = RuntimeError("stale session")
+    session_file = tmp_path / "monarch_session.pickle"
+    session_file.write_text("bad pickle", encoding="utf-8")
+
+    mc = MonarchClient(
+        email="",
+        password="",
+        cookie_string="session_id=cookie; csrftoken=csrf",
+        token="token",
+        mfa_secret="",
+        session_file=str(session_file),
+    )
+
+    asyncio.run(mc.login())
+
+    assert FakeMonarchMoney.instances[1].loaded_session_paths == [str(session_file)]
+    assert mc._mm.login_with_cookies_calls == [
+        {
+            "cookie_string": "session_id=cookie; csrftoken=csrf",
+            "save_session": True,
+            "verify": True,
+        }
+    ]
+    assert mc._mm.login_calls == []
+    assert mc._mm.calls_get_accounts == 1
+    assert not session_file.exists()
+
+
+def test_login_uses_token_compatibility_path(monkeypatch, tmp_path) -> None:
+    MonarchClient, FakeMonarchMoney = _import_monarch_client_with_fake_dep(monkeypatch)
+    session_file = tmp_path / "monarch_session.pickle"
+
+    mc = MonarchClient(
+        email="",
+        password="",
+        cookie_string="",
+        token="legacy-token",
+        mfa_secret="",
+        session_file=str(session_file),
+    )
+
+    asyncio.run(mc.login())
+
+    assert mc._mm.loaded_session_paths == []
+    assert mc._mm.login_with_cookies_calls == []
+    assert mc._mm.login_calls == []
+    assert mc._mm.calls_get_accounts == 1
+    assert mc._mm.saved_session_paths == [str(session_file)]
+
+
+def test_login_password_captcha_guides_cookie_bootstrap(monkeypatch, tmp_path) -> None:
+    MonarchClient, FakeMonarchMoney = _import_monarch_client_with_fake_dep(monkeypatch)
+    FakeMonarchMoney.login_error = FakeMonarchMoney.CaptchaRequiredException("CAPTCHA_REQUIRED")
+    session_file = tmp_path / "monarch_session.pickle"
+
+    mc = MonarchClient(
+        email="me@example.com",
+        password="secret",
+        cookie_string="",
+        token="",
+        mfa_secret="",
+        session_file=str(session_file),
+    )
+
+    with pytest.raises(RuntimeError, match="MONARCH_COOKIE_STRING"):
+        asyncio.run(mc.login())
 
 

--- a/tests/test_portal_smoke.py
+++ b/tests/test_portal_smoke.py
@@ -53,6 +53,19 @@ def _build_env(provider: str, *, base_env: dict[str, str]) -> dict[str, str]:
     return env
 
 
+def _has_monarch_auth(env: dict[str, str]) -> bool:
+    if env.get("MONARCH_COOKIE_STRING"):
+        return True
+    if env.get("MONARCH_COOKIE_SESSION_ID") and env.get("MONARCH_COOKIE_CSRFTOKEN"):
+        return True
+    if env.get("MONARCH_TOKEN"):
+        return True
+    if env.get("MONARCH_EMAIL") and env.get("MONARCH_PASSWORD"):
+        return True
+    session_file = Path(env.get("MONARCH_SESSION_FILE", str(ROOT / "data/monarch_session.pickle")))
+    return session_file.exists()
+
+
 def _skip_or_fail(reason: str) -> None:
     # Portal smoke tests require real credentials and should not fail local unit test runs by default.
     # To force failures locally (e.g., in a dedicated integration run), set REQUIRE_PORTAL_TESTS=1.
@@ -71,8 +84,10 @@ def _skip_if_missing(provider: str, *, env: dict[str, str], env_file: Optional[P
     if not env.get("LOAN_GROUPS"):
         _skip_or_fail(f"Missing LOAN_GROUPS for {provider}.")
 
-    if not env.get("MONARCH_TOKEN") and not (env.get("MONARCH_EMAIL") and env.get("MONARCH_PASSWORD")):
-        _skip_or_fail("Missing Monarch auth (MONARCH_TOKEN or MONARCH_EMAIL + MONARCH_PASSWORD).")
+    if not _has_monarch_auth(env):
+        _skip_or_fail(
+            "Missing Monarch auth (MONARCH_COOKIE_STRING, split cookie vars, MONARCH_EMAIL + MONARCH_PASSWORD, or saved session)."
+        )
 
     if os.getenv("PORTAL_SMOKE_SKIP_IMAP") != "1":
         if not env.get("GMAIL_IMAP_USER") or not env.get("GMAIL_IMAP_APP_PASSWORD"):


### PR DESCRIPTION
## Summary
- Add Monarch cookie bootstrap flow plus saved-session reuse so unattended runs can survive Monarch auth changes without interactive login.
- Update Monarch auth handling to prefer `data/monarch_session.pickle`, then cookie-string login, then the existing password/token compatibility paths.
- Refresh config, env examples, and README guidance so the new auth flow, split cookie vars, and pickle-only validation path are documented clearly.
- Add targeted tests for cookie parsing, login precedence, and the bootstrap command itself.

## Testing
- Unit coverage:
  - `python -m pytest tests/test_config.py tests/test_monarch_client_cache.py tests/test_cli_bootstrap_monarch_auth.py`
  - Covers cookie env parsing, saved-session reuse, cookie bootstrap, stale-session recovery, and bootstrap session capture.
- Local live validation on macOS with Python 3.11:
  - `python -m studentaid_monarch_sync bootstrap-monarch-auth`
  - Manual browser login completed and `data/monarch_session.pickle` was saved successfully.
  - `python -m studentaid_monarch_sync preflight`
  - `python -m studentaid_monarch_sync sync --dry-run`
  - `python -m studentaid_monarch_sync sync --dry-run --dry-run-check-monarch`
- Pickle-only validation:
  - Confirmed the saved Monarch session works with cookie vars unset, which is the path intended for Docker/Unraid.

## Notes
- The live validation used Python 3.11 because `monarchmoneycommunity==1.4.0` requires Python `>=3.10`.
- Docker/Unraid usage is still supported via the saved session file and persistent `data/` volume; no interactive login is needed on the box once the session pickle is bootstrapped.