### PR TITLE
feat(portal): add EdFinancial servicer support (account number + DOB device verification, parser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ See **Quick start → Runtime A: Docker (recommended)** for the Unraid schedulin
 - **Portal asks for SSN / Account Number + Date of Birth instead of emailing a code**
   - On an unrecognized device, some servicers (e.g. EdFinancial) show a step-up identity challenge (Account Number *or* SSN, plus Date of Birth) instead of sending an email code. The email poller then times out waiting for a code that never arrives.
   - Set `SERVICER_ACCOUNT_NUMBER` (preferred, so you do not store an SSN) or `SERVICER_SSN`, plus `SERVICER_DOB` (`MM/DD/YYYY`). The automation fills and submits the challenge, then saves the trusted session so the portal usually stops challenging (~90 days).
+  - If both are set, the account number is tried first; if it does not clear the challenge, the automation automatically retries with the SSN. If neither clears it (or only the account number is configured and it fails), the run stops with an actionable error telling you what to set.
   - Alternatively, run `sync --headful --manual-mfa` once and complete the page by hand to establish the trusted session.
 
 <a id="403-access-denied"></a>
@@ -358,6 +359,7 @@ See **Quick start → Runtime A: Docker (recommended)** for the Unraid schedulin
 - `monarch.payment_merchant_name`: merchant name to use when creating payment transactions, and the value used by the **duplicate guard**.
   - If your existing loan-account payments show up as **US Department of Education**, set this to that (recommended).
 - `monarch.duplicate_guard_use_reference` / `MONARCH_DUPLICATE_GUARD_USE_REFERENCE` (optional): when the portal provides a payment confirmation/reference, use it as a Monarch search term during duplicate detection to reduce false positives for same-day identical payments.
+- `monarch.duplicate_guard_loose_match` / `MONARCH_DUPLICATE_GUARD_LOOSE_MATCH` (optional, default off): the duplicate guard is **strict** by default (matches on **date + amount + merchant**). Enable this only if you intentionally rename payment merchants in Monarch — in loose mode the guard still tries a strict match first and falls back to **date + amount** (ignoring merchant) only if strict misses. A loose fallback is clearly logged whenever it skips creating a transaction.
 
 <a id="monarch-token"></a>
 ### Getting `MONARCH_TOKEN` (token-based auth for SSO)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Required:
 - Gmail IMAP (`GMAIL_IMAP_USER` + `GMAIL_IMAP_APP_PASSWORD`)
 
 Advanced (optional):
+- New-device verification (only needed if your servicer challenges unrecognized devices instead of emailing a code): set `SERVICER_ACCOUNT_NUMBER` (or `SERVICER_SSN`) plus `SERVICER_DOB`. See [Troubleshooting](#new-device-verification).
 - `config.example.yaml` is an advanced override file. You can pass `--config config.example.yaml`, but most users don’t need YAML at all.
 
 Tip: If you’re not sure what to put in `LOAN_GROUPS`, you can have the tool log into your servicer portal and list what it discovers:
@@ -336,6 +337,12 @@ See **Quick start → Runtime A: Docker (recommended)** for the Unraid schedulin
   - Confirm Gmail IMAP is enabled and `GMAIL_IMAP_FOLDER` matches the label name.
   - Set broad hints: `GMAIL_IMAP_SENDER_HINT=studentaid.gov` and `GMAIL_IMAP_SUBJECT_HINT=code`.
   - Make sure the filter applies the label and the email isn’t in Spam.
+
+<a id="new-device-verification"></a>
+- **Portal asks for SSN / Account Number + Date of Birth instead of emailing a code**
+  - On an unrecognized device, some servicers (e.g. EdFinancial) show a step-up identity challenge (Account Number *or* SSN, plus Date of Birth) instead of sending an email code. The email poller then times out waiting for a code that never arrives.
+  - Set `SERVICER_ACCOUNT_NUMBER` (preferred, so you do not store an SSN) or `SERVICER_SSN`, plus `SERVICER_DOB` (`MM/DD/YYYY`). The automation fills and submits the challenge, then saves the trusted session so the portal usually stops challenging (~90 days).
+  - Alternatively, run `sync --headful --manual-mfa` once and complete the page by hand to establish the trusted session.
 
 <a id="403-access-denied"></a>
 - **HTTP 403 Access Denied / portal blocks the headless browser**

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,6 +33,9 @@ monarch:
   # Optional: refine the Monarch-side duplicate guard by using the portal's payment confirmation/reference
   # number as a search term. Off by default.
   duplicate_guard_use_reference: "${MONARCH_DUPLICATE_GUARD_USE_REFERENCE}"
+  # Optional: loosen the duplicate guard. Strict by default (date + amount + merchant). When true, the guard
+  # tries strict first and falls back to date + amount only if strict misses (logged when it skips a create).
+  duplicate_guard_loose_match: "${MONARCH_DUPLICATE_GUARD_LOOSE_MATCH}"
   session_file: "data/monarch_session.pickle"
   # Optional: naming scheme for loan-group manual accounts (used for auto-mapping / auto-creation).
   # Placeholders: {provider}, {provider_upper}, {provider_display}, {group}

--- a/env.example
+++ b/env.example
@@ -7,6 +7,17 @@ SERVICER_PASSWORD=
 # MFA method supported by this automation: email
 SERVICER_MFA_METHOD=email
 
+# --- New-device identity challenge ---
+# Some servicers (e.g. EdFinancial) do NOT email a code on an unrecognized device. Instead
+# they show a step-up page asking for (Account Number OR SSN) AND Date of Birth. If these are
+# set, the automation answers that page so headless/unattended runs are not blocked. Account
+# number is preferred so you do not have to store an SSN. After passing it once the portal
+# trusts the saved session and usually stops challenging (~90 days).
+# DOB format: MM/DD/YYYY (MM-DD-YYYY and YYYY-MM-DD are also accepted).
+SERVICER_ACCOUNT_NUMBER=
+SERVICER_DOB=
+# SERVICER_SSN=   # optional fallback, only used if the account number is not accepted
+
 # --- Loan groups to sync (required) ---
 # Comma-separated list of loan group IDs from your servicer portal.
 # Common formats:

--- a/env.example
+++ b/env.example
@@ -14,9 +14,11 @@ SERVICER_MFA_METHOD=email
 # number is preferred so you do not have to store an SSN. After passing it once the portal
 # trusts the saved session and usually stops challenging (~90 days).
 # DOB format: MM/DD/YYYY (MM-DD-YYYY and YYYY-MM-DD are also accepted).
+# Fallback: if an account number is set but does not clear the challenge, the automation
+# automatically retries with SERVICER_SSN when configured; otherwise it fails with a clear error.
 SERVICER_ACCOUNT_NUMBER=
 SERVICER_DOB=
-# SERVICER_SSN=   # optional fallback, only used if the account number is not accepted
+# SERVICER_SSN=   # optional fallback, auto-tried if the account number does not clear the challenge
 
 # --- Loan groups to sync (required) ---
 # Comma-separated list of loan group IDs from your servicer portal.
@@ -53,6 +55,12 @@ MONARCH_MFA_SECRET=
 # Optional: refine the Monarch-side duplicate guard for payment transactions by using the portal's
 # confirmation/reference number (when present) as a search term. Off by default.
 MONARCH_DUPLICATE_GUARD_USE_REFERENCE=false
+
+# Optional: loosen the duplicate guard. Default (false) is strict: a transaction is a duplicate only
+# if date + amount + merchant all match. When true, the guard still tries a strict match first and
+# only falls back to date + amount (ignoring merchant) if strict misses — useful when you manually
+# rename the merchant on payments. A fallback match is logged clearly when it skips a create.
+MONARCH_DUPLICATE_GUARD_LOOSE_MATCH=false
 
 # Optional: naming template used when creating loan-group manual accounts in Monarch.
 # Placeholders: {provider}, {provider_upper}, {provider_display}, {group}

--- a/portal.env.example
+++ b/portal.env.example
@@ -25,9 +25,11 @@ SERVICER_MFA_METHOD=email
 # number is preferred so you do not have to store an SSN. After passing it once the portal
 # trusts the saved session and usually stops challenging (~90 days).
 # DOB format: MM/DD/YYYY (MM-DD-YYYY and YYYY-MM-DD are also accepted).
+# Fallback: if the account number is set but does not clear the challenge, the automation
+# automatically retries with SERVICER_SSN when configured; otherwise it fails with a clear error.
 SERVICER_ACCOUNT_NUMBER=
 SERVICER_DOB=
-# SERVICER_SSN=   # optional fallback, only used if the account number is not accepted
+# SERVICER_SSN=   # optional fallback, auto-tried if the account number does not clear the challenge
 
 # --- Loan groups to sync (required) ---
 # Used by the runtime and by the portal smoke tests to help parse payment allocation tables.
@@ -52,6 +54,9 @@ MONARCH_TOKEN=
 MONARCH_MFA_SECRET=
 
 MONARCH_DUPLICATE_GUARD_USE_REFERENCE=false
+# Strict by default (date + amount + merchant). Set true to allow a date+amount-only fallback when
+# strict misses (e.g. you rename payment merchants). Loose fallbacks are logged when they skip a create.
+MONARCH_DUPLICATE_GUARD_LOOSE_MATCH=false
 MONARCH_LOAN_ACCOUNT_NAME_TEMPLATE={provider}-{group}
 
 # --- Runtime toggles ---

--- a/portal.env.example
+++ b/portal.env.example
@@ -18,6 +18,17 @@ SERVICER_PASSWORD=
 # MFA method supported by this automation: email
 SERVICER_MFA_METHOD=email
 
+# --- New-device identity challenge ---
+# Some servicers (e.g. EdFinancial) do NOT email a code on an unrecognized device. Instead
+# they show a step-up page asking for (Account Number OR SSN) AND Date of Birth. If these are
+# set, the automation answers that page so headless/unattended runs are not blocked. Account
+# number is preferred so you do not have to store an SSN. After passing it once the portal
+# trusts the saved session and usually stops challenging (~90 days).
+# DOB format: MM/DD/YYYY (MM-DD-YYYY and YYYY-MM-DD are also accepted).
+SERVICER_ACCOUNT_NUMBER=
+SERVICER_DOB=
+# SERVICER_SSN=   # optional fallback, only used if the account number is not accepted
+
 # --- Loan groups to sync (required) ---
 # Used by the runtime and by the portal smoke tests to help parse payment allocation tables.
 LOAN_GROUPS=AA,AB,AC,AD,AE,AF,AG

--- a/src/studentaid_monarch_sync/cli.py
+++ b/src/studentaid_monarch_sync/cli.py
@@ -311,12 +311,12 @@ def main(argv: Optional[List[str]] = None) -> int:
                 portal = ServicerPortalClient(
                     base_url=cfg.servicer.base_url,
                     creds=PortalCredentials(
-                username=cfg.servicer.username,
-                password=cfg.servicer.password,
-                account_number=cfg.servicer.account_number,
-                date_of_birth=cfg.servicer.date_of_birth,
-                ssn=cfg.servicer.ssn,
-            ),
+                        username=cfg.servicer.username,
+                        password=cfg.servicer.password,
+                        account_number=cfg.servicer.account_number,
+                        date_of_birth=cfg.servicer.date_of_birth,
+                        ssn=cfg.servicer.ssn,
+                    ),
                 )
 
                 mfa_provider = lambda: poll_gmail_imap_for_code(cfg.gmail_imap, print_code=args.print_mfa_code)
@@ -746,6 +746,7 @@ async def _log_dry_run_with_monarch(cfg, state: StateStore, loan_snapshots, paym
             search=(alloc.payment_reference or "").strip()
             if getattr(cfg.monarch, "duplicate_guard_use_reference", False)
             else "",
+            loose_match=getattr(cfg.monarch, "duplicate_guard_loose_match", False),
         )
         if dup:
             would_skip_dup += 1
@@ -1185,6 +1186,7 @@ async def _apply_monarch_updates(
             search=(alloc.payment_reference or "").strip()
             if getattr(cfg.monarch, "duplicate_guard_use_reference", False)
             else "",
+            loose_match=getattr(cfg.monarch, "duplicate_guard_loose_match", False),
         )
         if dup:
             logger.info(

--- a/src/studentaid_monarch_sync/cli.py
+++ b/src/studentaid_monarch_sync/cli.py
@@ -310,7 +310,13 @@ def main(argv: Optional[List[str]] = None) -> int:
 
                 portal = ServicerPortalClient(
                     base_url=cfg.servicer.base_url,
-                    creds=PortalCredentials(username=cfg.servicer.username, password=cfg.servicer.password),
+                    creds=PortalCredentials(
+                username=cfg.servicer.username,
+                password=cfg.servicer.password,
+                account_number=cfg.servicer.account_number,
+                date_of_birth=cfg.servicer.date_of_birth,
+                ssn=cfg.servicer.ssn,
+            ),
                 )
 
                 mfa_provider = lambda: poll_gmail_imap_for_code(cfg.gmail_imap, print_code=args.print_mfa_code)
@@ -427,7 +433,13 @@ def main(argv: Optional[List[str]] = None) -> int:
 
         portal = ServicerPortalClient(
             base_url=cfg.servicer.base_url,
-            creds=PortalCredentials(username=cfg.servicer.username, password=cfg.servicer.password),
+            creds=PortalCredentials(
+                username=cfg.servicer.username,
+                password=cfg.servicer.password,
+                account_number=cfg.servicer.account_number,
+                date_of_birth=cfg.servicer.date_of_birth,
+                ssn=cfg.servicer.ssn,
+            ),
         )
         mfa_provider = lambda: poll_gmail_imap_for_code(cfg.gmail_imap, print_code=args.print_mfa_code)
 
@@ -490,7 +502,13 @@ def main(argv: Optional[List[str]] = None) -> int:
 
         portal = ServicerPortalClient(
             base_url=cfg.servicer.base_url,
-            creds=PortalCredentials(username=cfg.servicer.username, password=cfg.servicer.password),
+            creds=PortalCredentials(
+                username=cfg.servicer.username,
+                password=cfg.servicer.password,
+                account_number=cfg.servicer.account_number,
+                date_of_birth=cfg.servicer.date_of_birth,
+                ssn=cfg.servicer.ssn,
+            ),
         )
 
         mfa_provider = lambda: poll_gmail_imap_for_code(cfg.gmail_imap, print_code=args.print_mfa_code)

--- a/src/studentaid_monarch_sync/config.py
+++ b/src/studentaid_monarch_sync/config.py
@@ -128,6 +128,10 @@ def _default_config_from_env() -> dict:
             "username": os.getenv("SERVICER_USERNAME", ""),
             "password": os.getenv("SERVICER_PASSWORD", ""),
             "mfa_method": os.getenv("SERVICER_MFA_METHOD", "email"),
+            # New-device identity challenge (account number/SSN + DOB) for servicers like EdFinancial.
+            "account_number": os.getenv("SERVICER_ACCOUNT_NUMBER", ""),
+            "date_of_birth": os.getenv("SERVICER_DOB", ""),
+            "ssn": os.getenv("SERVICER_SSN", ""),
         },
         "gmail_imap": {
             "user": os.getenv("GMAIL_IMAP_USER", ""),
@@ -174,6 +178,11 @@ class ServicerConfig(BaseModel):
     username: str
     password: str
     mfa_method: Literal["email"] = "email"
+    # New-device identity challenge (account number/SSN + DOB) for servicers like EdFinancial.
+    # repr-hidden so secrets do not leak into logs.
+    account_number: str = Field(default="", repr=False)
+    date_of_birth: str = Field(default="", repr=False)
+    ssn: str = Field(default="", repr=False)
 
     @model_validator(mode="after")
     def _fill_defaults_and_validate(self) -> "ServicerConfig":

--- a/src/studentaid_monarch_sync/config.py
+++ b/src/studentaid_monarch_sync/config.py
@@ -212,6 +212,16 @@ class ServicerConfig(BaseModel):
         if not parsed.scheme or not parsed.netloc:
             raise ValueError(f"servicer.base_url must be a full URL like 'https://{provider}.studentaid.gov'")
 
+        # Validate optional SSN: if provided, must be exactly 9 digits (ignoring separators
+        # like dashes/spaces). Fail fast at config load instead of mid-run on the portal so a
+        # fat-fingered extra/missing digit doesn't waste a full automation run.
+        ssn_digits = re.sub(r"\D", "", self.ssn or "")
+        if self.ssn and len(ssn_digits) != 9:
+            raise ValueError(
+                "servicer.ssn must be a 9-digit Social Security Number "
+                "(dashes/spaces allowed, e.g. '123-45-6789')"
+            )
+
         self.provider = provider
         self.base_url = base_url
         return self

--- a/src/studentaid_monarch_sync/config.py
+++ b/src/studentaid_monarch_sync/config.py
@@ -154,6 +154,9 @@ def _default_config_from_env() -> dict:
             # Optional: refine the Monarch-side duplicate guard by using the portal's payment reference
             # (confirmation number) as a search term. Off by default because it relies on Monarch search semantics.
             "duplicate_guard_use_reference": _env_bool("MONARCH_DUPLICATE_GUARD_USE_REFERENCE", default=False),
+            # Optional: opt-in loose duplicate matching (strict date+amount+merchant by default; loose falls
+            # back to date+amount only when strict misses). See MonarchConfig.duplicate_guard_loose_match.
+            "duplicate_guard_loose_match": _env_bool("MONARCH_DUPLICATE_GUARD_LOOSE_MATCH", default=False),
         },
         "state": {
             "db_path": os.getenv("STATE_DB_PATH", "data/state.db"),
@@ -245,6 +248,10 @@ class MonarchConfig(BaseModel):
     # Optional: when the portal provides a confirmation/reference for a payment, use it as a search term
     # for Monarch duplicate detection to reduce false positives when two payments share date+amount+merchant.
     duplicate_guard_use_reference: bool = False
+    # Optional: opt-in loose duplicate matching. Default is strict (date + amount + merchant). When enabled,
+    # the guard tries a strict match first and only falls back to date + amount (ignoring merchant) if strict
+    # misses — useful when manually-entered transactions use a different merchant name than sync-created ones.
+    duplicate_guard_loose_match: bool = False
 
     @model_validator(mode="after")
     def _validate_auth(self) -> "MonarchConfig":

--- a/src/studentaid_monarch_sync/monarch/client.py
+++ b/src/studentaid_monarch_sync/monarch/client.py
@@ -404,15 +404,18 @@ class MonarchClient:
         date_window_days: int = 0,
         max_pages: int = 5,
         search: str = "",
-        require_merchant_match: bool = False,
+        loose_match: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """
-        Look for an existing transaction matching date + amount (+ optionally merchant).
-        Returns the matching transaction dict if found.
+        Look for an existing transaction matching the payment, to avoid creating duplicates.
 
-        Merchant matching is off by default: account_id + date + amount is specific enough
-        for loan payment accounts, and manually-entered transactions may use a different
-        merchant name than the sync-created ones.
+        Default behavior is **strict**: a transaction must match date + amount + merchant. This is the
+        safe default — it won't treat an unrelated same-day, same-amount transaction as a duplicate.
+
+        When ``loose_match`` is enabled (opt-in via ``MONARCH_DUPLICATE_GUARD_LOOSE_MATCH``), we still try
+        a strict match first and only fall back to a date + amount match (ignoring merchant) if strict
+        misses. This helps when a manually-entered transaction uses a different merchant name than the
+        sync-created ones. When a loose fallback is used, we log a clear line so the skip is auditable.
 
         We page through results because Monarch may return more than our per-request limit for
         a date range (especially if a user has many transactions on a given day).
@@ -427,6 +430,10 @@ class MonarchClient:
         want_amount_cents = int(amount_cents)
         want_merchant = (merchant_name or "").strip().lower()
         search_term = (search or "").strip()
+
+        # In loose mode we keep scanning for a strict (merchant-matching) hit, but remember the first
+        # date+amount-only match as a fallback to use if no strict hit turns up.
+        loose_candidate: Optional[Dict[str, Any]] = None
 
         for page in range(pages):
             txns = await self.list_transactions(
@@ -443,15 +450,25 @@ class MonarchClient:
                     continue
                 if _dollars_to_cents(t.get("amount")) != want_amount_cents:
                     continue
-                if require_merchant_match:
-                    got_merchant = _txn_merchant_name(t).strip().lower()
-                    if got_merchant != want_merchant:
-                        continue
-                return t
+                got_merchant = _txn_merchant_name(t).strip().lower()
+                if got_merchant == want_merchant:
+                    return t  # strict match: date + amount + merchant
+                if loose_match and loose_candidate is None:
+                    loose_candidate = t
 
             # If we didn't fill the page, there are no more results.
             if len(txns) < page_size:
                 break
+
+        if loose_candidate is not None:
+            logger.info(
+                "Duplicate guard: no strict date+amount+merchant match; using LOOSE date+amount match "
+                "txn id=%s (merchant differs: got %r want %r)",
+                loose_candidate.get("id") or "",
+                _txn_merchant_name(loose_candidate),
+                merchant_name,
+            )
+            return loose_candidate
 
         return None
 

--- a/src/studentaid_monarch_sync/monarch/client.py
+++ b/src/studentaid_monarch_sync/monarch/client.py
@@ -404,10 +404,15 @@ class MonarchClient:
         date_window_days: int = 0,
         max_pages: int = 5,
         search: str = "",
+        require_merchant_match: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """
-        Look for an existing transaction matching date + amount + merchant.
+        Look for an existing transaction matching date + amount (+ optionally merchant).
         Returns the matching transaction dict if found.
+
+        Merchant matching is off by default: account_id + date + amount is specific enough
+        for loan payment accounts, and manually-entered transactions may use a different
+        merchant name than the sync-created ones.
 
         We page through results because Monarch may return more than our per-request limit for
         a date range (especially if a user has many transactions on a given day).
@@ -438,9 +443,10 @@ class MonarchClient:
                     continue
                 if _dollars_to_cents(t.get("amount")) != want_amount_cents:
                     continue
-                got_merchant = _txn_merchant_name(t).strip().lower()
-                if got_merchant != want_merchant:
-                    continue
+                if require_merchant_match:
+                    got_merchant = _txn_merchant_name(t).strip().lower()
+                    if got_merchant != want_merchant:
+                        continue
                 return t
 
             # If we didn't fill the page, there are no more results.

--- a/src/studentaid_monarch_sync/portal/client.py
+++ b/src/studentaid_monarch_sync/portal/client.py
@@ -40,6 +40,11 @@ class PortalAccessDeniedError(RuntimeError):
 class PortalCredentials:
     username: str
     password: str
+    # Used to answer a new-device identity challenge (account number/SSN + DOB) shown by
+    # some servicers (e.g. EdFinancial) on an unrecognized device instead of an email code.
+    account_number: str = ""
+    date_of_birth: str = ""  # MM/DD/YYYY (also accepts MM-DD-YYYY or YYYY-MM-DD)
+    ssn: str = ""
 
 
 class ServicerPortalClient:
@@ -61,6 +66,9 @@ class ServicerPortalClient:
         parsed = urlparse(self.base_url)
         self._canonical_host = (parsed.netloc or "").strip().lower()
         self._dark_host = f"dark.{self._canonical_host}" if self._canonical_host else ""
+        # Provider slug derived from host (e.g. "edfinancial" from edfinancial.studentaid.gov).
+        # Used to gate provider-specific behavior so other servicers are unaffected.
+        self.provider = self._canonical_host.split(".")[0] if self._canonical_host else ""
 
         # Step-by-step debug (screenshots) — configured per `extract()` call.
         self._step_log_enabled: bool = False
@@ -499,6 +507,8 @@ class ServicerPortalClient:
 
                         # Navigate to loan details and parse "Group:" headers.
                         self._wait_for_post_login_ready(page, debug_dir=debug_dir, timeout_ms=90_000)
+                        if self.provider == "edfinancial":
+                            return self._edf_discover_loan_groups(page, debug_dir=debug_dir)
                         self._goto_section(page, self.selectors.nav_my_loans_text, debug_dir=debug_dir)
 
                         # Some portals render multiple "My Loans" targets (nav, dashboard cards, footer).
@@ -886,7 +896,15 @@ class ServicerPortalClient:
 
         page.wait_for_timeout(1500)
 
-        if self._looks_like_mfa(page):
+        # EdFinancial: on an unrecognized device the portal shows an identity challenge
+        # (account number/SSN + DOB) before/instead of an email code. Handle it first.
+        self._maybe_complete_device_verification(page, debug_dir=debug_dir, manual_mfa=manual_mfa)
+
+        # Passing that challenge can land us on the authenticated dashboard, whose numeric
+        # inputs (e.g. "Custom Pay") can look like a code field. Only treat the page as MFA
+        # when not already logged in. Gated to edfinancial so other providers are unchanged.
+        already_logged_in = self.provider == "edfinancial" and self._looks_logged_in(page)
+        if not already_logged_in and self._looks_like_mfa(page):
             if mfa_method != "email":
                 raise RuntimeError(f"Only email MFA is supported by this automation (got: {mfa_method})")
             self._step(page, debug_dir=debug_dir, name="mfa_detected")
@@ -1029,6 +1047,15 @@ class ServicerPortalClient:
                     return True
             except Exception:
                 continue
+
+        # EdFinancial Account Summary signals (gated so other providers are unaffected).
+        if self.provider == "edfinancial":
+            for txt in ("Total Current Balance", "Total Payment Due", "$0 Balance Loans"):
+                try:
+                    if page.get_by_text(txt, exact=False).count() > 0:
+                        return True
+                except Exception:
+                    continue
 
         # Authenticated main navigation items (stable in HTML snapshots).
         try:
@@ -1469,6 +1496,330 @@ class ServicerPortalClient:
                 return True
         return False
 
+    def _type_into(self, page: Page, selector: str, value: str, *, timeout_ms: int = 8000) -> None:
+        """Click + type one keystroke at a time (keystroke-masked fields need real key events)."""
+        loc = page.locator(selector).first
+        loc.wait_for(state="visible", timeout=timeout_ms)
+        try:
+            loc.click()
+        except Exception:
+            pass
+        try:
+            loc.fill("")
+        except Exception:
+            pass
+        try:
+            loc.press_sequentially(value, delay=70)
+        except Exception:
+            loc.type(value, delay=70)
+        try:
+            loc.blur()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _parse_dob(value: str) -> tuple:
+        """Parse a DOB string into (MM, DD, YYYY). Accepts MM/DD/YYYY, MM-DD-YYYY, YYYY-MM-DD."""
+        groups = [g for g in re.split(r"[^0-9]+", (value or "").strip()) if g]
+        if len(groups) != 3:
+            return ("", "", "")
+        a, b, c = groups
+        if len(a) == 4:
+            year, month, day = a, b, c
+        else:
+            month, day, year = a, b, c
+        if len(year) == 2:
+            year = ("19" if int(year) > 30 else "20") + year
+        return (month.zfill(2), day.zfill(2), year.zfill(4))
+
+    def _maybe_complete_device_verification(self, page: Page, *, debug_dir: str, manual_mfa: bool = False) -> None:
+        """
+        Handle EdFinancial's "we don't recognize this device" identity challenge.
+
+        Only runs for the edfinancial provider. On an unrecognized device the portal asks for
+        SSN (or Account Number) AND Date of Birth instead of emailing a code. If account_number/ssn
+        + date_of_birth are configured, fill and submit so the run can proceed unattended.
+        """
+        if self.provider != "edfinancial":
+            return
+        sel = self.selectors
+        try:
+            page.locator(sel.device_verify_detect).first.wait_for(state="visible", timeout=8000)
+        except Exception:
+            return
+        self._step(page, debug_dir=debug_dir, name="device_verify_detected")
+        logger.info("Detected new-device identity challenge (account number/SSN + DOB).")
+        acct = (self.creds.account_number or "").strip()
+        ssn = re.sub(r"\D", "", self.creds.ssn or "")
+        dob = (self.creds.date_of_birth or "").strip()
+        if not dob or not (acct or ssn):
+            if manual_mfa:
+                logger.info("Manual mode: complete device verification (account number/SSN + DOB) in the browser.")
+                deadline = time.time() + 180
+                while time.time() < deadline:
+                    try:
+                        if not page.locator(sel.device_verify_detect).first.is_visible():
+                            return
+                    except Exception:
+                        return
+                    page.wait_for_timeout(500)
+                self._save_debug(page, debug_dir=debug_dir, name_prefix="device_verify_manual_timeout")
+                raise TimeoutError("Timed out waiting for manual device verification.")
+            self._save_debug(page, debug_dir=debug_dir, name_prefix="device_verify_unconfigured")
+            raise RuntimeError(
+                "Portal requires new-device verification (account number/SSN + date of birth), but none are "
+                "configured. Set SERVICER_ACCOUNT_NUMBER (or SERVICER_SSN) and SERVICER_DOB, or re-run with "
+                "--headful --manual-mfa to complete it by hand."
+            )
+        month, day, year = self._parse_dob(dob)
+        if not (month and day and year):
+            raise RuntimeError(f"Could not parse SERVICER_DOB={dob!r}; expected MM/DD/YYYY.")
+        try:
+            if acct:
+                self._type_into(page, sel.device_verify_account_input, acct)
+            else:
+                for selector, part in zip(sel.device_verify_ssn_inputs, (ssn[0:3], ssn[3:5], ssn[5:9])):
+                    self._type_into(page, selector, part)
+            self._type_into(page, sel.device_verify_dob_month, month)
+            self._type_into(page, sel.device_verify_dob_day, day)
+            self._type_into(page, sel.device_verify_dob_year, year)
+            self._step(page, debug_dir=debug_dir, name="device_verify_filled")
+            page.locator(sel.device_verify_submit).first.click()
+            self._wait_for_settle(page, timeout_ms=30_000)
+            self._step(page, debug_dir=debug_dir, name="device_verify_submitted")
+            logger.info("Submitted new-device identity challenge.")
+        except Exception:
+            self._save_debug(page, debug_dir=debug_dir, name_prefix="device_verify_failure")
+            raise
+    # ------------------------------------------------------------------
+    # EdFinancial-specific parsing (server-rendered myaccount.* app)
+    # ------------------------------------------------------------------
+
+    def _edf_app_url(self, path: str) -> str:
+        host = self._canonical_host or "edfinancial.studentaid.gov"
+        return f"https://myaccount.{host}{path}"
+
+    def _edf_goto(self, page: Page, path: str, *, wait_text=None, timeout_ms: int = 45000) -> None:
+        page.goto(self._edf_app_url(path), wait_until="domcontentloaded", timeout=timeout_ms)
+        self._wait_for_settle(page, timeout_ms=timeout_ms)
+        if wait_text:
+            self._wait_for_body_text_contains(page, wait_text, timeout_ms=timeout_ms)
+        else:
+            page.wait_for_timeout(1500)
+
+    def _edf_read_only_table(self, page: Page) -> list:
+        js = (
+            "() => { const t = document.querySelector('table'); if (!t) return []; "
+            "return Array.from(t.querySelectorAll('tr')).map(r => "
+            "Array.from(r.querySelectorAll('th,td')).map(c => (c.innerText||'').trim())); }"
+        )
+        try:
+            return page.evaluate(js) or []
+        except Exception:
+            return []
+
+    @staticmethod
+    def _edf_money_to_cents(s: str) -> int:
+        s = s or ""
+        neg = ("-" in s) or ("(" in s)
+        digits = re.sub(r"[^0-9.]", "", s)
+        if not digits:
+            return 0
+        val = int(round(float(digits) * 100))
+        return -val if neg else val
+
+    @staticmethod
+    def _edf_group_token(loan_name: str) -> str:
+        m = re.match(r"\s*(\d+-\d+)", loan_name or "")
+        return m.group(1) if m else ""
+
+    @staticmethod
+    def _edf_parse_mdy(s: str):
+        m = re.match(r"\s*(\d{1,2})/(\d{1,2})/(\d{4})", s or "")
+        if not m:
+            return None
+        return date(int(m.group(3)), int(m.group(1)), int(m.group(2)))
+
+    @staticmethod
+    def _edf_header_index(header: list, needle: str) -> int:
+        for i, h in enumerate(header):
+            if needle in (h or "").lower():
+                return i
+        return -1
+
+    def _edf_load_loan_rows(self, page: Page, *, debug_dir: str) -> list:
+        self._edf_goto(page, "/Loans/AllLoanDetails", wait_text="Current Balance")
+        self._step(page, debug_dir=debug_dir, name="edf_all_loan_details")
+        matrix = self._edf_read_only_table(page)
+        rows = []
+        if not matrix:
+            return rows
+        header = matrix[0]
+        ci_loan = self._edf_header_index(header, "loan")
+        ci_bal = self._edf_header_index(header, "current balance")
+        ci_rate = self._edf_header_index(header, "interest rate")
+        ci_due = self._edf_header_index(header, "due")
+        for r in matrix[1:]:
+            if not r or all(not c for c in r):
+                continue
+            name = r[ci_loan] if 0 <= ci_loan < len(r) else (r[0] if r else "")
+            token = self._edf_group_token(name)
+            if not token:
+                continue
+            rows.append({
+                "token": token,
+                "label": (name or "").strip(),
+                "balance_cents": self._edf_money_to_cents(r[ci_bal]) if 0 <= ci_bal < len(r) else 0,
+                "rate": (r[ci_rate].strip() if 0 <= ci_rate < len(r) else None),
+                "due": (r[ci_due].strip() if 0 <= ci_due < len(r) else ""),
+            })
+        return rows
+
+    def _edf_discover_loan_groups(self, page: Page, *, debug_dir: str) -> list:
+        rows = self._edf_load_loan_rows(page, debug_dir=debug_dir)
+        out = []
+        seen = set()
+        for r in rows:
+            if r["token"] in seen:
+                continue
+            out.append((r["token"], r["label"]))
+            seen.add(r["token"])
+        if not out:
+            self._save_debug(page, debug_dir=debug_dir, name_prefix="edf_no_loans_found")
+        return out
+
+    def _edf_extract_loans(self, page: Page, *, groups: list, debug_dir: str, allow_empty_loans: bool = False) -> list:
+        rows = self._edf_load_loan_rows(page, debug_dir=debug_dir)
+        by_token = {r["token"]: r for r in rows}
+        want = [g.strip() for g in (groups or []) if (g or "").strip()] or [r["token"] for r in rows]
+        out = []
+        for g in want:
+            r = by_token.get(g)
+            if not r:
+                if allow_empty_loans:
+                    continue
+                raise RuntimeError(f"EdFinancial: loan group {g!r} not found on All Loan Details page.")
+            bal = r["balance_cents"]
+            out.append(LoanSnapshot(
+                group=g,
+                principal_balance_cents=bal,
+                accrued_interest_cents=0,
+                outstanding_balance_cents=bal,
+                due_date=self._edf_parse_mdy(r["due"]),
+                raw_effective_interest_rate=r["rate"],
+            ))
+        return out
+
+    def _edf_select(self, page: Page, name: str, value: str) -> bool:
+        try:
+            page.select_option(f"select#{name}, select[name='{name}']", value, timeout=6000)
+            self._wait_for_settle(page, timeout_ms=20000)
+            page.wait_for_timeout(1000)
+            return True
+        except Exception as e:
+            logger.warning("EdFinancial: could not select %s=%s (%s)", name, value, e)
+            return False
+
+    def _edf_ddl_value_for_group(self, page: Page, group: str):
+        js = (
+            "() => { const s=document.querySelector('select#ddl_Loan, select[name=ddl_Loan]'); "
+            "if(!s) return []; return Array.from(s.options).map(o=>({v:o.value,t:(o.textContent||'').trim()})); }"
+        )
+        try:
+            opts = page.evaluate(js) or []
+        except Exception:
+            opts = []
+        for o in opts:
+            if self._edf_group_token(o.get("t", "")) == group:
+                return o.get("v")
+        return None
+
+    def _edf_parse_history_rows(self, matrix: list) -> list:
+        if not matrix:
+            return []
+        header = matrix[0]
+        h_date = self._edf_header_index(header, "date")
+        h_desc = self._edf_header_index(header, "description")
+        h_pr = self._edf_header_index(header, "principal")
+        h_int = self._edf_header_index(header, "interest")
+        h_tot = self._edf_header_index(header, "total")
+        if h_date < 0:
+            h_date = 0
+        rows = []
+        for r in matrix[1:]:
+            if not r:
+                continue
+            # In the "By Loan" view each row carries a leading expand/disclosure cell, which
+            # shifts every column right by a fixed offset versus the header. Locate the real
+            # (standalone) date cell and map all columns relative to it. Detail/expansion rows
+            # without a standalone date cell are naturally skipped (prevents double-counting).
+            di = -1
+            for i, cell in enumerate(r):
+                if self._edf_parse_mdy(cell) is not None:
+                    di = i
+                    break
+            if di < 0:
+                continue
+            offset = di - h_date
+
+            def at(hi: int, _r=r, _off=offset) -> str:
+                if hi < 0:
+                    return ""
+                j = hi + _off
+                return _r[j] if 0 <= j < len(_r) else ""
+
+            d = self._edf_parse_mdy(at(h_date))
+            if not d:
+                continue
+            desc = at(h_desc).strip().lower()
+            typ = "payment" if "payment" in desc else ("disbursement" if "disburse" in desc else "other")
+            rows.append({
+                "date": d,
+                "type": typ,
+                "principal_cents": self._edf_money_to_cents(at(h_pr)),
+                "interest_cents": self._edf_money_to_cents(at(h_int)),
+                "total_cents": self._edf_money_to_cents(at(h_tot)),
+            })
+        return rows
+
+    def _edf_extract_payment_allocations(self, page: Page, *, groups: list, debug_dir: str, payments_since=None) -> list:
+        want = [g.strip() for g in (groups or []) if (g or "").strip()]
+        self._edf_goto(page, "/AccountHistory/ViewHistory", wait_text="History")
+        self._step(page, debug_dir=debug_dir, name="edf_history_loaded")
+        per_loan = {}
+        date_totals = {}
+        for g in want:
+            # Per-loan, life-of-loan view. Re-assert each iteration in case a postback resets selects.
+            self._edf_select(page, "SelctedHistType", "2")
+            self._edf_select(page, "SelectedDateRange", "5")
+            val = self._edf_ddl_value_for_group(page, g)
+            if val is None:
+                logger.warning("EdFinancial: no loan-history option for group %s; skipping.", g)
+                continue
+            self._edf_select(page, "ddl_Loan", val)
+            rows = self._edf_parse_history_rows(self._edf_read_only_table(page))
+            self._step(page, debug_dir=debug_dir, name=f"edf_history_{g}")
+            per_loan[g] = rows
+            for row in rows:
+                if row["type"] == "payment":
+                    date_totals[row["date"]] = date_totals.get(row["date"], 0) + abs(row["total_cents"])
+        out = []
+        for g, rows in per_loan.items():
+            for row in rows:
+                if row["type"] != "payment":
+                    continue
+                if payments_since and row["date"] < payments_since:
+                    continue
+                out.append(PaymentAllocation(
+                    payment_date=row["date"],
+                    group=g,
+                    total_applied_cents=abs(row["total_cents"]),
+                    principal_applied_cents=abs(row["principal_cents"]),
+                    interest_applied_cents=abs(row["interest_cents"]),
+                    payment_total_cents=date_totals.get(row["date"], abs(row["total_cents"])),
+                ))
+        return out
+
     def _complete_email_mfa(self, page: Page, mfa_code_provider: Callable[[], str], *, debug_dir: str) -> None:
         # Best-effort click Email option if present.
         try:
@@ -1602,6 +1953,11 @@ class ServicerPortalClient:
         self._step(page, debug_dir=debug_dir, name="loans_before_nav_my_loans")
         # Race-condition guard: on slower machines the app may still be on the post-login callback screen.
         self._wait_for_post_login_ready(page, debug_dir=debug_dir, timeout_ms=90_000)
+
+        if self.provider == "edfinancial":
+            return self._edf_extract_loans(
+                page, groups=groups, debug_dir=debug_dir, allow_empty_loans=allow_empty_loans
+            )
 
         # Try nav first (best-effort), but fall back to direct navigation if nav isn't ready/available.
         self._goto_section(page, self.selectors.nav_my_loans_text, debug_dir=debug_dir)
@@ -2038,6 +2394,11 @@ class ServicerPortalClient:
 
         # Best-effort: navigate to payment activity and open the first N payment details.
         self._wait_for_post_login_ready(page, debug_dir=debug_dir, timeout_ms=90_000)
+
+        if self.provider == "edfinancial":
+            return self._edf_extract_payment_allocations(
+                page, groups=groups, debug_dir=debug_dir, payments_since=payments_since
+            )
         self._step(page, debug_dir=debug_dir, name="payments_before_nav_payment_activity")
         self._goto_section(page, self.selectors.nav_payment_activity_text, debug_dir=debug_dir)
         self._step(page, debug_dir=debug_dir, name="payments_after_nav_payment_activity")

--- a/src/studentaid_monarch_sync/portal/client.py
+++ b/src/studentaid_monarch_sync/portal/client.py
@@ -1539,6 +1539,10 @@ class ServicerPortalClient:
         Only runs for the edfinancial provider. On an unrecognized device the portal asks for
         SSN (or Account Number) AND Date of Birth instead of emailing a code. If account_number/ssn
         + date_of_birth are configured, fill and submit so the run can proceed unattended.
+
+        Fallback: when an account number is configured we try it first; if that does not clear the
+        challenge and an SSN is configured, we automatically retry with the SSN. If nothing clears it
+        (or the required values are missing) we fail fast with an actionable error.
         """
         if self.provider != "edfinancial":
             return
@@ -1574,8 +1578,62 @@ class ServicerPortalClient:
         month, day, year = self._parse_dob(dob)
         if not (month and day and year):
             raise RuntimeError(f"Could not parse SERVICER_DOB={dob!r}; expected MM/DD/YYYY.")
+        self._complete_device_challenge_with_fallback(
+            page, acct=acct, ssn=ssn, month=month, day=day, year=year, debug_dir=debug_dir
+        )
+
+    def _complete_device_challenge_with_fallback(
+        self, page: Page, *, acct: str, ssn: str, month: str, day: str, year: str, debug_dir: str
+    ) -> None:
+        """
+        Try account number + DOB first (if configured), then fall back to SSN + DOB if the challenge
+        remains. Raise an actionable error if neither path clears it.
+        """
+        tried_account = False
+        tried_ssn = False
+        if acct:
+            tried_account = True
+            if self._edf_submit_device_challenge(
+                page, mode="account", acct=acct, ssn=ssn, month=month, day=day, year=year, debug_dir=debug_dir
+            ):
+                logger.info("New-device identity challenge cleared using account number.")
+                return
+            logger.info("Account-number device verification did not clear the challenge; trying SSN if configured.")
+        if ssn:
+            tried_ssn = True
+            if self._edf_submit_device_challenge(
+                page, mode="ssn", acct=acct, ssn=ssn, month=month, day=day, year=year, debug_dir=debug_dir
+            ):
+                logger.info("New-device identity challenge cleared using SSN.")
+                return
+            logger.info("SSN device verification did not clear the challenge.")
+        self._save_debug(page, debug_dir=debug_dir, name_prefix="device_verify_failure")
+        if tried_account and tried_ssn:
+            raise RuntimeError(
+                "New-device verification failed with both account number and SSN. Verify SERVICER_ACCOUNT_NUMBER, "
+                "SERVICER_SSN, and SERVICER_DOB are correct, or re-run with --headful --manual-mfa."
+            )
+        if tried_account:
+            raise RuntimeError(
+                "New-device verification with the account number failed and no SERVICER_SSN is configured to fall "
+                "back to. Set SERVICER_SSN (and verify SERVICER_DOB), or re-run with --headful --manual-mfa."
+            )
+        raise RuntimeError(
+            "New-device verification with SSN failed. Verify SERVICER_SSN and SERVICER_DOB are correct, or re-run "
+            "with --headful --manual-mfa."
+        )
+
+    def _edf_submit_device_challenge(
+        self, page: Page, *, mode: str, acct: str, ssn: str, month: str, day: str, year: str, debug_dir: str
+    ) -> bool:
+        """
+        Fill and submit the device-verification form using ``mode`` ("account" or "ssn"), then report
+        whether the challenge cleared (i.e. the detection form is no longer visible). An exception while
+        filling/submitting is treated as "not cleared" so the caller can fall back to the other credential.
+        """
+        sel = self.selectors
         try:
-            if acct:
+            if mode == "account":
                 self._type_into(page, sel.device_verify_account_input, acct)
             else:
                 for selector, part in zip(sel.device_verify_ssn_inputs, (ssn[0:3], ssn[3:5], ssn[5:9])):
@@ -1583,14 +1641,24 @@ class ServicerPortalClient:
             self._type_into(page, sel.device_verify_dob_month, month)
             self._type_into(page, sel.device_verify_dob_day, day)
             self._type_into(page, sel.device_verify_dob_year, year)
-            self._step(page, debug_dir=debug_dir, name="device_verify_filled")
+            self._step(page, debug_dir=debug_dir, name=f"device_verify_filled_{mode}")
             page.locator(sel.device_verify_submit).first.click()
             self._wait_for_settle(page, timeout_ms=30_000)
-            self._step(page, debug_dir=debug_dir, name="device_verify_submitted")
-            logger.info("Submitted new-device identity challenge.")
+            self._step(page, debug_dir=debug_dir, name=f"device_verify_submitted_{mode}")
+            logger.info("Submitted new-device identity challenge via %s.", mode)
         except Exception:
-            self._save_debug(page, debug_dir=debug_dir, name_prefix="device_verify_failure")
-            raise
+            logger.warning("Device verification attempt via %s raised; treating as not cleared.", mode, exc_info=True)
+            self._save_debug(page, debug_dir=debug_dir, name_prefix=f"device_verify_{mode}_error")
+            return False
+        # The challenge cleared if its detection form is no longer visible.
+        try:
+            page.locator(sel.device_verify_detect).first.wait_for(state="hidden", timeout=8000)
+            return True
+        except Exception:
+            try:
+                return not page.locator(sel.device_verify_detect).first.is_visible()
+            except Exception:
+                return True
     # ------------------------------------------------------------------
     # EdFinancial-specific parsing (server-rendered myaccount.* app)
     # ------------------------------------------------------------------

--- a/src/studentaid_monarch_sync/portal/selectors.py
+++ b/src/studentaid_monarch_sync/portal/selectors.py
@@ -45,6 +45,23 @@ class PortalSelectors:
     mfa_code_input: str = 'input[type="tel"], input[inputmode="numeric"], input[name*="code" i]'
     mfa_verify_text: str = "Verify"
 
+    # New-device identity challenge ("We don't recognize the device you're using").
+    # EdFinancial shows this instead of an email code on an unrecognized device.
+    # Section 1: SSN (3 fields) OR Account Number. Section 2: Date of Birth (MM/DD/YYYY).
+    device_verify_detect: str = (
+        '#account-number, #lblSSN1, input[name="taccountNumber"], input[name="tSSN1"], input[name="tmonth"]'
+    )
+    device_verify_account_input: str = '#account-number, input[name="taccountNumber"]'
+    device_verify_ssn_inputs: tuple = (
+        'input[name="tSSN1"]',
+        'input[name="tSSN2"]',
+        'input[name="tSSN3"]',
+    )
+    device_verify_dob_month: str = '#dob1, input[name="tmonth"]'
+    device_verify_dob_day: str = '#dob2, input[name="tday"]'
+    device_verify_dob_year: str = 'input[name="tyear"]'
+    device_verify_submit: str = '#Submit, button[name="Submit"], button.submit'
+
     # Navigation
     nav_my_loans_text: tuple[str, ...] = ("My Loans", "My Loan", "Loans")
     nav_payment_activity_text: tuple[str, ...] = ("Payment Activity", "Payment History", "Payments")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from studentaid_monarch_sync.config import _derive_provider_from_base_url, load_config
+from studentaid_monarch_sync.config import (
+    ServicerConfig,
+    _derive_provider_from_base_url,
+    load_config,
+)
 
 
 def _write(tmp_path: Path, name: str, text: str) -> Path:
@@ -83,6 +87,23 @@ monarch:
     )
     with pytest.raises(Exception):
         _ = load_config(cfg_path)
+
+
+def _servicer(ssn: str) -> ServicerConfig:
+    return ServicerConfig(provider="edfinancial", username="u", password="p", ssn=ssn)
+
+
+@pytest.mark.parametrize("ssn", ["123456789", "123-45-6789", "123 45 6789", ""])
+def test_servicer_ssn_accepts_valid_and_empty(ssn: str) -> None:
+    # 9 digits (with or without separators) pass; empty is allowed since SSN is optional.
+    cfg = _servicer(ssn)
+    assert cfg.ssn == ssn
+
+
+@pytest.mark.parametrize("ssn", ["12345678", "1234567890", "123-45-678", "12-345-67890"])
+def test_servicer_ssn_rejects_wrong_length(ssn: str) -> None:
+    with pytest.raises(ValueError, match="ssn"):
+        _servicer(ssn)
 
 
 def test_invalid_provider_slug_rejected(tmp_path: Path) -> None:

--- a/tests/test_duplicate_guard.py
+++ b/tests/test_duplicate_guard.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+from studentaid_monarch_sync.monarch.client import MonarchClient
+
+DATE = "2026-01-15"
+MERCHANT = "Student Loan Payment"
+AMOUNT_CENTS = 10000  # $100.00
+
+
+def _txn(txn_id: str, *, date: str = DATE, amount: float = 100.0, merchant: str = MERCHANT) -> Dict[str, Any]:
+    return {"id": txn_id, "date": date, "amount": amount, "merchant": {"name": merchant}}
+
+
+class _FakeMonarch(MonarchClient):
+    """Bypass MonarchMoney/network; serve canned transactions to find_duplicate_transaction."""
+
+    def __init__(self, txns: List[Dict[str, Any]]) -> None:
+        self._txns = list(txns)
+
+    async def list_transactions(self, **kwargs: Any) -> List[Dict[str, Any]]:  # type: ignore[override]
+        return list(self._txns)
+
+
+def _find(client: MonarchClient, **kwargs: Any) -> Dict[str, Any] | None:
+    return asyncio.run(
+        client.find_duplicate_transaction(
+            account_id="acct",
+            posted_date_iso=DATE,
+            amount_cents=AMOUNT_CENTS,
+            merchant_name=MERCHANT,
+            **kwargs,
+        )
+    )
+
+
+def test_strict_match_returns_on_date_amount_merchant() -> None:
+    client = _FakeMonarch([_txn("1")])
+    dup = _find(client)
+    assert dup is not None and dup["id"] == "1"
+
+
+def test_strict_default_does_not_match_when_merchant_differs() -> None:
+    client = _FakeMonarch([_txn("1", merchant="EdFinancial")])
+    assert _find(client) is None
+
+
+def test_loose_mode_falls_back_to_date_amount_when_strict_misses() -> None:
+    client = _FakeMonarch([_txn("1", merchant="EdFinancial")])
+    dup = _find(client, loose_match=True)
+    assert dup is not None and dup["id"] == "1"
+
+
+def test_loose_mode_still_prefers_strict_hit() -> None:
+    # Loose candidate appears first, strict hit second — strict must win.
+    client = _FakeMonarch([_txn("loose", merchant="EdFinancial"), _txn("strict")])
+    dup = _find(client, loose_match=True)
+    assert dup is not None and dup["id"] == "strict"
+
+
+def test_no_candidate_returns_none() -> None:
+    # Different date → neither strict nor loose matches.
+    client = _FakeMonarch([_txn("1", date="2026-02-01")])
+    assert _find(client) is None
+    assert _find(client, loose_match=True) is None
+
+
+def test_amount_mismatch_is_not_a_loose_candidate() -> None:
+    client = _FakeMonarch([_txn("1", amount=99.0, merchant="EdFinancial")])
+    assert _find(client, loose_match=True) is None

--- a/tests/test_edf_device_verification.py
+++ b/tests/test_edf_device_verification.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pytest
+
+from studentaid_monarch_sync.portal.client import PortalCredentials, ServicerPortalClient
+from studentaid_monarch_sync.portal.selectors import PortalSelectors
+
+
+def _client(*, account_number: str = "", ssn: str = "", dob: str = "01/02/1990") -> ServicerPortalClient:
+    return ServicerPortalClient(
+        base_url="https://edfinancial.studentaid.gov",
+        creds=PortalCredentials(
+            username="u",
+            password="p",
+            account_number=account_number,
+            ssn=ssn,
+            date_of_birth=dob,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_dob
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("03/07/1985", ("03", "07", "1985")),
+        ("3-7-1985", ("03", "07", "1985")),
+        ("1985-03-07", ("03", "07", "1985")),
+        ("12/31/2000", ("12", "31", "2000")),
+    ],
+)
+def test_parse_dob_formats(value: str, expected: Tuple[str, str, str]) -> None:
+    assert ServicerPortalClient._parse_dob(value) == expected
+
+
+def test_parse_dob_two_digit_year_boundary() -> None:
+    # > 30 -> 19xx, <= 30 -> 20xx
+    assert ServicerPortalClient._parse_dob("01/01/31")[2] == "1931"
+    assert ServicerPortalClient._parse_dob("01/01/30")[2] == "2030"
+
+
+@pytest.mark.parametrize("value", ["", "not a date", "01/2020", "1/2/3/4"])
+def test_parse_dob_malformed(value: str) -> None:
+    assert ServicerPortalClient._parse_dob(value) == ("", "", "")
+
+
+# ---------------------------------------------------------------------------
+# Fallback orchestration: _complete_device_challenge_with_fallback
+# ---------------------------------------------------------------------------
+
+
+def _script_attempts(client: ServicerPortalClient, results: dict[str, bool]) -> List[str]:
+    """Patch the submit seam to return scripted clears per mode; record the attempt order."""
+    attempts: List[str] = []
+
+    def fake_submit(page, *, mode, acct, ssn, month, day, year, debug_dir):
+        attempts.append(mode)
+        return results.get(mode, False)
+
+    client._edf_submit_device_challenge = fake_submit  # type: ignore[assignment]
+    client._save_debug = lambda *a, **k: None  # type: ignore[assignment]
+    return attempts
+
+
+def _run_fallback(client: ServicerPortalClient, *, acct: str, ssn: str) -> None:
+    client._complete_device_challenge_with_fallback(
+        object(), acct=acct, ssn=ssn, month="01", day="02", year="1990", debug_dir="/tmp"
+    )
+
+
+def test_account_path_succeeds_without_ssn_attempt() -> None:
+    client = _client(account_number="123", ssn="111223333")
+    attempts = _script_attempts(client, {"account": True})
+    _run_fallback(client, acct="123", ssn="111223333")
+    assert attempts == ["account"]
+
+
+def test_account_fails_then_ssn_succeeds() -> None:
+    client = _client(account_number="123", ssn="111223333")
+    attempts = _script_attempts(client, {"account": False, "ssn": True})
+    _run_fallback(client, acct="123", ssn="111223333")
+    assert attempts == ["account", "ssn"]
+
+
+def test_account_fails_no_ssn_raises_actionable_error() -> None:
+    client = _client(account_number="123", ssn="")
+    attempts = _script_attempts(client, {"account": False})
+    with pytest.raises(RuntimeError, match="SERVICER_SSN"):
+        _run_fallback(client, acct="123", ssn="")
+    assert attempts == ["account"]
+
+
+def test_ssn_only_path_fails_raises() -> None:
+    client = _client(account_number="", ssn="111223333")
+    attempts = _script_attempts(client, {"ssn": False})
+    with pytest.raises(RuntimeError, match="SSN"):
+        _run_fallback(client, acct="", ssn="111223333")
+    assert attempts == ["ssn"]
+
+
+def test_both_paths_fail_raises_mentioning_both() -> None:
+    client = _client(account_number="123", ssn="111223333")
+    attempts = _script_attempts(client, {"account": False, "ssn": False})
+    with pytest.raises(RuntimeError, match="both"):
+        _run_fallback(client, acct="123", ssn="111223333")
+    assert attempts == ["account", "ssn"]
+
+
+# ---------------------------------------------------------------------------
+# _edf_submit_device_challenge: "cleared" detection
+# ---------------------------------------------------------------------------
+
+
+class _Loc:
+    def __init__(self, *, hidden: bool) -> None:
+        self._hidden = hidden
+
+    @property
+    def first(self) -> "_Loc":
+        return self
+
+    def click(self) -> None:
+        pass
+
+    def wait_for(self, *, state: str, timeout: int) -> None:
+        if state == "hidden" and not self._hidden:
+            raise RuntimeError("still visible")
+
+    def is_visible(self) -> bool:
+        return not self._hidden
+
+
+class _Page:
+    def __init__(self, *, detect_hidden: bool) -> None:
+        self._detect = _Loc(hidden=detect_hidden)
+        self._other = _Loc(hidden=True)
+
+    def locator(self, selector: str) -> _Loc:
+        if selector == PortalSelectors().device_verify_detect:
+            return self._detect
+        return self._other
+
+
+def _patch_fill_helpers(client: ServicerPortalClient) -> None:
+    client._type_into = lambda *a, **k: None  # type: ignore[assignment]
+    client._step = lambda *a, **k: None  # type: ignore[assignment]
+    client._wait_for_settle = lambda *a, **k: None  # type: ignore[assignment]
+    client._save_debug = lambda *a, **k: None  # type: ignore[assignment]
+
+
+def test_submit_reports_cleared_when_detect_hidden() -> None:
+    client = _client(account_number="123")
+    _patch_fill_helpers(client)
+    page = _Page(detect_hidden=True)
+    cleared = client._edf_submit_device_challenge(
+        page, mode="account", acct="123", ssn="", month="01", day="02", year="1990", debug_dir="/tmp"
+    )
+    assert cleared is True
+
+
+def test_submit_reports_not_cleared_when_detect_still_visible() -> None:
+    client = _client(account_number="123")
+    _patch_fill_helpers(client)
+    page = _Page(detect_hidden=False)
+    cleared = client._edf_submit_device_challenge(
+        page, mode="account", acct="123", ssn="", month="01", day="02", year="1990", debug_dir="/tmp"
+    )
+    assert cleared is False

--- a/tests/test_portal_smoke.py
+++ b/tests/test_portal_smoke.py
@@ -129,3 +129,11 @@ def test_cri_preflight_and_dry_run() -> None:
 @pytest.mark.portal
 def test_nelnet_preflight_and_dry_run() -> None:
     _run_preflight_and_dry_run("nelnet")
+
+
+@pytest.mark.portal
+def test_edfinancial_preflight_and_dry_run() -> None:
+    # EdFinancial verifies new devices with account number/SSN + DOB instead of an emailed code, so a
+    # local run typically sets PORTAL_SMOKE_SKIP_IMAP=1 and provides SERVICER_ACCOUNT_NUMBER (and/or
+    # SERVICER_SSN) + SERVICER_DOB in the env file. Skipped unless those credentials are configured.
+    _run_preflight_and_dry_run("edfinancial")


### PR DESCRIPTION
Closes #8

## What

Adds support for **EdFinancial** as a servicer provider. EdFinancial's portal differs from the existing Nelnet-style flow in two ways, and this PR handles both.
Every change is gated to `provider == "edfinancial"`, so other servicers (Nelnet, Aidvantage, MOHELA, etc.) are completely unaffected.

## Why (addresses #8)

As reported in #8, two things break the existing flow for EdFinancial:

1. **New-device identity challenge.** On a cookie-less / unrecognized device, EdFinancial does not email an MFA code. Instead it shows a step-up page asking for (account number **or** SSN) and date of birth, so the login form's username field is never found and the email MFA poller waits for a code that never arrives.
2. **Different portal structure.** After login the authenticated app is server-rendered at `myaccount.edfinancial.studentaid.gov`, not the Nelnet-style `Group:` layout, so the existing loan/payment parsing finds nothing.

Per the maintainer's note in #8 (no SSN-centric workflow), **account number + DOB is the primary, documented path**. SSN is supported only as an optional, repr-hidden fallback (it's never required and is not the default).

## What changed

**Device verification** (`client.py`, `selectors.py`, `config.py`)
- New `_maybe_complete_device_verification` fills and submits the challenge, then proceeds to the dashboard. It is a no-op for any non-edfinancial provider.
- Selectors targeted (from the challenge page in #8):
  - Account number: `#account-number` / `input[name="taccountNumber"]`
  - SSN (optional fallback): `input[name="tSSN1"]`, `tSSN2`, `tSSN3`
  - Date of birth: `#dob1`/`input[name="tmonth"]`, `#dob2`/`input[name="tday"]`, `input[name="tyear"]`
  - Submit: `#Submit`
  - These fields are keystroke-masked, so the automation types character-by-character rather than using `fill`.
- After the challenge, login can land directly on the dashboard, whose numeric inputs can look like a code field. Added an edfinancial-gated "already logged in" guard so a logged-in page is not misread as an MFA prompt. For other providers this guard is always false, so their MFA path is unchanged.
- The portal's click-through agree page before the login prompt is handled by the existing post-login readiness wait.
- New optional config: `SERVICER_ACCOUNT_NUMBER`, `SERVICER_DOB`, and (optional) `SERVICER_SSN`, all repr-hidden so they do not leak into logs.

**EdFinancial parser** (`client.py`)
- `discover_loan_groups`, `_extract_loans`, and `_extract_payment_allocations` each branch to an `_edf_*` implementation only for edfinancial; the existing code path is untouched.
- Balances, rates, and due dates are parsed from `/Loans/AllLoanDetails`.
- Per-loan payment allocations are parsed from `/AccountHistory/ViewHistory` using the "By Loan" / "Life of Loan" view. That view prepends an expand/disclosure cell that shifts every column, so the row parser locates the real date cell and maps columns relative to it (this also skips detail/expansion rows, avoiding double-counting).

**Docs/templates**
- `env.example`, `portal.env.example`, and `README.md` document the new variables and add a troubleshooting entry for the new-device challenge.

## Safety / blast radius

- All behavioral changes are behind a `provider == "edfinancial"` (or `!= "edfinancial"`) check derived from the portal host. No existing provider's behavior changes.
- The new config fields default to empty and are optional. SSN is never required.

## Testing

Validated read-only against a live EdFinancial account (no writes to Monarch):
- Loan-group discovery returns the correct groups.
- Loan balances, interest rates, and due dates match the portal.
- Per-loan payment allocations parse correctly, and the per-date splits reconcile to the expected monthly autopay total.

## Notes

- Only read-only paths were exercised; the balance/transaction-writing `sync` was not run against a live Monarch account in this validation.
- Happy to share sanitized selector/flow detail on #8 if useful; raw portal HTML is omitted since it contains account PII.